### PR TITLE
docs: add agent instructions, dev workflow, and architecture docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot Instructions
+
+See [AGENTS.md](../AGENTS.md) for all project instructions, development rules, and conventions.

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -174,8 +174,8 @@ fi
 
 cd "$REPO_ROOT"
 
-# SPECS_DIR used temporarily for feature numbering (checking existing branches/specs)
 SPECS_DIR="$REPO_ROOT/specs"
+mkdir -p "$SPECS_DIR"
 
 # Function to generate branch name with stop word filtering and length filtering
 generate_branch_name() {
@@ -271,21 +271,11 @@ if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
     >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
 fi
 
-WORKTREE_PATH="$(dirname "$REPO_ROOT")/$(basename "$REPO_ROOT")-${BRANCH_NAME}"
-
 if [ "$HAS_GIT" = true ]; then
-    git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME"
-    # Symlink gitignored files required by dev tasks into the new worktree
-    for f in age.key kubeconfig; do
-        [ -f "$REPO_ROOT/$f" ] && ln -sf "$REPO_ROOT/$f" "$WORKTREE_PATH/$f"
-    done
+    git checkout -b "$BRANCH_NAME"
 else
     >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
-    WORKTREE_PATH="$REPO_ROOT"
 fi
-
-SPECS_DIR="$WORKTREE_PATH/specs"
-mkdir -p "$SPECS_DIR"
 
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
 mkdir -p "$FEATURE_DIR"
@@ -298,11 +288,10 @@ if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"
 export SPECIFY_FEATURE="$BRANCH_NAME"
 
 if $JSON_MODE; then
-    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s","WORKTREE_PATH":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM" "$WORKTREE_PATH"
+    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM"
 else
     echo "BRANCH_NAME: $BRANCH_NAME"
     echo "SPEC_FILE: $SPEC_FILE"
     echo "FEATURE_NUM: $FEATURE_NUM"
-    echo "WORKTREE_PATH: $WORKTREE_PATH"
     echo "SPECIFY_FEATURE environment variable set to: $BRANCH_NAME"
 fi

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -174,8 +174,8 @@ fi
 
 cd "$REPO_ROOT"
 
+# SPECS_DIR used temporarily for feature numbering (checking existing branches/specs)
 SPECS_DIR="$REPO_ROOT/specs"
-mkdir -p "$SPECS_DIR"
 
 # Function to generate branch name with stop word filtering and length filtering
 generate_branch_name() {
@@ -271,11 +271,21 @@ if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
     >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
 fi
 
+WORKTREE_PATH="$(dirname "$REPO_ROOT")/$(basename "$REPO_ROOT")-${BRANCH_NAME}"
+
 if [ "$HAS_GIT" = true ]; then
-    git checkout -b "$BRANCH_NAME"
+    git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME"
+    # Symlink gitignored files required by dev tasks into the new worktree
+    for f in age.key kubeconfig; do
+        [ -f "$REPO_ROOT/$f" ] && ln -sf "$REPO_ROOT/$f" "$WORKTREE_PATH/$f"
+    done
 else
     >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+    WORKTREE_PATH="$REPO_ROOT"
 fi
+
+SPECS_DIR="$WORKTREE_PATH/specs"
+mkdir -p "$SPECS_DIR"
 
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
 mkdir -p "$FEATURE_DIR"
@@ -288,10 +298,11 @@ if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"
 export SPECIFY_FEATURE="$BRANCH_NAME"
 
 if $JSON_MODE; then
-    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM"
+    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s","WORKTREE_PATH":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM" "$WORKTREE_PATH"
 else
     echo "BRANCH_NAME: $BRANCH_NAME"
     echo "SPEC_FILE: $SPEC_FILE"
     echo "FEATURE_NUM: $FEATURE_NUM"
+    echo "WORKTREE_PATH: $WORKTREE_PATH"
     echo "SPECIFY_FEATURE environment variable set to: $BRANCH_NAME"
 fi

--- a/.taskfiles/dev/Taskfile.yaml
+++ b/.taskfiles/dev/Taskfile.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: '3'
+tasks:
+  validate:
+    desc: Validate Flux manifests locally with flux-local (no cluster needed)
+    vars:
+      # renovate: datasource=docker depName=ghcr.io/allenporter/flux-local
+      FLUX_LOCAL_IMAGE: ghcr.io/allenporter/flux-local:v8.1.0
+    cmd: >-
+      docker run --rm -v {{.ROOT_DIR}}:/github/workspace {{.FLUX_LOCAL_IMAGE}} test --enable-helm --all-namespaces --path /github/workspace/kubernetes/flux/cluster -v
+    preconditions:
+      - which docker
+  start:
+    desc: Switch Flux to reconcile the current git branch [must not be on main]
+    vars:
+      BRANCH:
+        sh: git branch --show-current
+    cmds:
+      - task: _guard-not-main
+        vars: {BRANCH: '{{.BRANCH}}'}
+      - git push origin {{.BRANCH}}
+      - flux suspend helmrelease flux-instance -n flux-system
+      - kubectl patch gitrepository flux-system -n flux-system --type=merge -p '{"spec":{"ref":{"name":"refs/heads/{{.BRANCH}}"}}}'
+      - flux -n flux-system reconcile source git flux-system
+      - flux -n flux-system reconcile kustomization flux-system
+    preconditions:
+      - test -f {{.KUBECONFIG}}
+      - which flux kubectl git
+  sync:
+    desc: Push current branch and trigger Flux to reconcile it
+    vars:
+      BRANCH:
+        sh: git branch --show-current
+    cmds:
+      - task: _guard-not-main
+        vars: {BRANCH: '{{.BRANCH}}'}
+      - git push origin {{.BRANCH}}
+      - flux -n flux-system reconcile source git flux-system
+      - flux -n flux-system reconcile kustomization flux-system
+    preconditions:
+      - test -f {{.KUBECONFIG}}
+      - which flux git
+  stop:
+    desc: Restore Flux to watch main and resume normal reconciliation
+    cmds:
+      - kubectl patch gitrepository flux-system -n flux-system --type=merge -p '{"spec":{"ref":{"name":"refs/heads/main"}}}'
+      - flux resume helmrelease flux-instance -n flux-system
+      - flux -n flux-system reconcile source git flux-system
+      - flux -n flux-system reconcile kustomization flux-system
+    preconditions:
+      - test -f {{.KUBECONFIG}}
+      - which flux kubectl
+  _guard-not-main:
+    internal: true
+    requires:
+      vars: [BRANCH]
+    cmd: |
+      if [ "{{.BRANCH}}" = "main" ]; then
+        echo "Error: dev tasks cannot be used on the main branch"
+        exit 1
+      fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,13 @@ task dev:validate   # renders all Flux HelmReleases and Kustomizations — no cl
 Always work in a git worktree to keep the main checkout on `main` and isolate feature branches:
 
 ```bash
-# Create a worktree for the feature branch
+# Create a worktree for the feature branch (sibling of the main checkout)
 git worktree add ../home-ops-my-change -b feature/my-change
 cd ../home-ops-my-change
+
+# Symlink gitignored files required by dev tasks
+ln -s ../home-ops/age.key age.key
+ln -s ../home-ops/kubeconfig kubeconfig
 
 # edit kubernetes/ manifests
 task lint             # auto-fix formatting
@@ -62,7 +66,7 @@ task dev:start        # push branch, suspend flux-instance HelmRelease, patch Gi
 task dev:sync         # push additional commits and reconcile
 task dev:stop         # ALWAYS run this — restores flux-instance and points cluster back at main
 
-# Clean up the worktree when done
+# Clean up the worktree when done (must be run from outside the worktree)
 cd ../home-ops
 git worktree remove ../home-ops-my-change
 ```
@@ -114,8 +118,11 @@ Replicate CI locally with `task dev:validate` before opening a PR.
   `main`. All other hooks must pass.
 - **`yamlfmt` reformats indentation and multiline strings** — do not manually fight its style;
   always let `task lint` normalize files before committing.
-- **Worktrees share the `.git` directory** — gitignored files (`age.key`, `kubeconfig`, etc.) exist
-  only in the main working tree; symlink or copy them into the worktree if needed.
+- **Worktrees share the `.git` directory but not gitignored files** — `age.key` and `kubeconfig`
+  exist only in the main working tree. Always symlink them into a new worktree before running
+  `dev:` tasks (`ln -s ../home-ops/age.key age.key`, same for `kubeconfig`).
+- **`git worktree remove` must be run from outside the worktree** — `cd` to the main checkout
+  first, then remove.
 
 ## Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Always work in a git worktree to keep the main checkout on `main` and isolate fe
 git worktree add ../home-ops-my-change -b feature/my-change
 cd ../home-ops-my-change
 
-# Symlink gitignored files required by dev tasks
+# Symlink gitignored files required by dev tasks (Taskfile resolves these from ROOT_DIR)
 ln -s ../home-ops/age.key age.key
 ln -s ../home-ops/kubeconfig kubeconfig
 
@@ -119,10 +119,9 @@ Replicate CI locally with `task dev:validate` before opening a PR.
 - **`yamlfmt` reformats indentation and multiline strings** — do not manually fight its style;
   always let `task lint` normalize files before committing.
 - **Worktrees share the `.git` directory but not gitignored files** — `age.key` and `kubeconfig`
-  exist only in the main working tree. Always symlink them into a new worktree before running
-  `dev:` tasks (`ln -s ../home-ops/age.key age.key`, same for `kubeconfig`).
-- **`git worktree remove` must be run from outside the worktree** — `cd` to the main checkout
-  first, then remove.
+  exist only in the main working tree. Symlink them into the worktree before running `dev:` tasks —
+  the Taskfile resolves these from `ROOT_DIR` so env var overrides won't work:
+  `ln -s ../home-ops/age.key age.key && ln -s ../home-ops/kubeconfig kubeconfig`.
 
 ## Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,112 @@
 # AGENTS.md
 
-This is the [juftin/home-ops](https://github.com/juftin/home-ops) repository. This project
-defines a GitOps-driven Kubernetes cluster hosted on bare metal. The cluster
-is designed to run various applications and services, including home automation
-and media management tools.
-
-This repository was created from an upstream template:
-[onedr0p/cluster-template](https://github.com/onedr0p/cluster-template). The template
-provides a structured starting point for setting up a Kubernetes cluster with GitOps
-principles, allowing for easy management and deployment of applications and services.
-
-Apart from the underlying template, this project is heavily influenced by the
-onedr0p/home-ops](https://github.com/onedr0p/home-ops) repository where the creator
-has expanded on the template with additional applications and components.
-
-## README.md
-
-The [README.md](README.md) file provides an overview of the project, including
-key components, infrastructure details, and a list of applications and services.
+This is the [juftin/home-ops](https://github.com/juftin/home-ops) repository — a GitOps-driven
+Kubernetes homelab on bare metal. Flux continuously reconciles `kubernetes/` from `main`. Talos
+Linux is the OS. Secrets are SOPS-encrypted with age. Dependencies are updated by Renovate.
 
 @README.md
+@docs/ARCHITECTURE.md
+@docs/TASKS.md
 
-## Adding New Components and Apps
+## Environment Setup
 
-When adding new components or applications to the cluster, examining the
-[onedr0p/home-ops](https://github.com/onedr0p/home-ops) repository can provide
-valuable insights and examples. [kubesearch.dev](https://kubesearch.dev/)
-is also a great resource for finding Kubernetes manifests and configurations
-for various applications.
+Run once after cloning:
+
+```bash
+mise install          # install all pinned tools (.mise.toml)
+pre-commit install    # install git hooks
+```
+
+Gitignored files that must exist locally:
+
+| File                              | How to get it                          |
+| --------------------------------- | -------------------------------------- |
+| `age.key`                         | Age private key — run `task decrypt`   |
+| `kubeconfig`                      | Kubernetes config — run `task decrypt` |
+| `talos/clusterconfig/talosconfig` | Run `task talos:generate-config`       |
+
+## Validation — Always Run Before Finishing
+
+Run these in order before considering any task complete:
+
+```bash
+task lint           # auto-fixes YAML/Markdown formatting; run until clean (second run always passes)
+task dev:validate   # renders all Flux HelmReleases and Kustomizations — no cluster required
+```
+
+## Development Rules
+
+- **Never commit directly to `main`** — pre-commit blocks it; always use a feature branch.
+- **Never store plaintext secrets** — all `*.sops.yaml` files must be SOPS-encrypted. `task configure`
+  encrypts them automatically. Never leave decrypted secrets uncommitted.
+- **Do not use `kubectl apply` to test changes** — Flux has `prune: true` and will overwrite direct
+  applies at the next reconcile. Use the branch testing workflow instead.
+- **Always run `task lint` before committing** — `yamlfmt` and `mdformat` auto-fix files in place;
+  committing un-formatted files fails CI.
+
+## Branch Testing Workflow
+
+To deploy changes to the live cluster without merging to `main`:
+
+```bash
+git checkout -b feature/my-change
+# edit kubernetes/ manifests
+task lint             # auto-fix formatting
+task dev:validate     # validate offline
+task dev:start        # push branch, suspend flux-instance HelmRelease, patch GitRepository, reconcile
+task dev:sync         # push additional commits and reconcile
+task dev:stop         # ALWAYS run this — restores flux-instance and points cluster back at main
+```
+
+> Always run `task dev:stop` when done, even if something went wrong. It restores the
+> `flux-instance` HelmRelease and resets the cluster to track `main`.
+
+## Adding a New App
+
+All apps live under `kubernetes/apps/<namespace>/<app-name>/`. Exact structure:
+
+```
+kubernetes/apps/<namespace>/
+├── kustomization.yaml      # add a resources entry pointing at the new ks.yaml
+├── namespace.yaml          # Namespace manifest (if new namespace)
+└── <app-name>/
+    ├── ks.yaml             # Flux Kustomization for this app
+    └── app/
+        ├── kustomization.yaml
+        ├── ocirepository.yaml  # OCI Helm chart source
+        ├── helmrelease.yaml    # HelmRelease with chart values
+        └── *.sops.yaml         # SOPS-encrypted secrets (if needed)
+```
+
+Use `kubernetes/apps/default/echo/` as a working reference. After adding files:
+
+1. Add a `resources:` entry in the parent namespace `kustomization.yaml` for the new `ks.yaml`
+2. Run `task lint` then `task dev:validate`
+3. Use `task dev:start` / `task dev:sync` to test on the live cluster
+4. Update **`README.md`** — add the app to the `## Apps` or `## Components` section
+5. Update **`docs/ARCHITECTURE.md`** — add the app to the namespaces table and any relevant layer description
+
+## CI — What Runs on Pull Requests
+
+PRs to `main` with changes under `kubernetes/` trigger two jobs:
+
+1. **`flux-local test`** — renders all HelmReleases and Kustomizations; fails on any render error
+2. **`flux-local diff`** — diffs changed `helmrelease` and `kustomization` resources vs `main`, posted as a PR comment
+
+Replicate CI locally with `task dev:validate` before opening a PR.
+
+## Gotchas
+
+- **SOPS files are valid YAML with encrypted values** — never `kubectl apply` them directly. Flux
+  decrypts them in-cluster via the `sops-age` secret.
+- **`task dev:start` suspends `flux-instance` HelmRelease** — the flux-operator manages the
+  `flux-system` GitRepository and would immediately reset any branch patch without this suspension.
+- **`task lint` always fails on `main`** — the `no-commit-to-branch` hook is expected to fail on
+  `main`. All other hooks must pass.
+- **`yamlfmt` reformats indentation and multiline strings** — do not manually fight its style;
+  always let `task lint` normalize files before committing.
+
+## Resources
+
+- [onedr0p/home-ops](https://github.com/onedr0p/home-ops) — reference app implementations
+- [kubesearch.dev](https://kubesearch.dev/) — community Kubernetes app configs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+This is the [juftin/home-ops](https://github.com/juftin/home-ops) repository. This project
+defines a GitOps-driven Kubernetes cluster hosted on bare metal. The cluster
+is designed to run various applications and services, including home automation
+and media management tools.
+
+This repository was created from an upstream template:
+[onedr0p/cluster-template](https://github.com/onedr0p/cluster-template). The template
+provides a structured starting point for setting up a Kubernetes cluster with GitOps
+principles, allowing for easy management and deployment of applications and services.
+
+Apart from the underlying template, this project is heavily influenced by the
+onedr0p/home-ops](https://github.com/onedr0p/home-ops) repository where the creator
+has expanded on the template with additional applications and components.
+
+## README.md
+
+The [README.md](README.md) file provides an overview of the project, including
+key components, infrastructure details, and a list of applications and services.
+
+@README.md
+
+## Adding New Components and Apps
+
+When adding new components or applications to the cluster, examining the
+[onedr0p/home-ops](https://github.com/onedr0p/home-ops) repository can provide
+valuable insights and examples. [kubesearch.dev](https://kubesearch.dev/)
+is also a great resource for finding Kubernetes manifests and configurations
+for various applications.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,10 +15,16 @@ env:
   TALOSCONFIG: '{{.TALOSCONFIG}}'
 includes:
   bootstrap: .taskfiles/bootstrap
+  dev: .taskfiles/dev
   talos: .taskfiles/talos
   template: .taskfiles/template
 tasks:
   default: task --list
+  lint:
+    desc: Run pre-commit hooks against all files
+    cmd: pre-commit run --all-files
+    preconditions:
+      - which pre-commit
   reconcile:
     desc: Force Flux to pull in changes from your Git repository
     cmd: flux --namespace flux-system reconcile kustomization flux-system --with-source

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,237 @@
+# Architecture
+
+This document describes how the `home-ops` repository is structured and how its components work
+together to manage a GitOps-driven Kubernetes homelab.
+
+______________________________________________________________________
+
+## Overview
+
+The cluster is a single-node Kubernetes cluster running on bare metal using
+[Talos Linux](https://talos.dev/) as the OS. All cluster state is declared in this Git repository
+and continuously reconciled by [Flux](https://fluxcd.io/). Secrets are encrypted at rest using
+[SOPS](https://github.com/getsops/sops) with an [age](https://github.com/FiloSottile/age) key.
+Dependency updates are automated with [Renovate](https://renovatebot.com/).
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  GitHub Repository (home-ops)                                   │
+│                                                                 │
+│  ┌──────────┐  ┌─────────────┐  ┌──────────┐  ┌────────────┐  │
+│  │  talos/  │  │ kubernetes/ │  │bootstrap/│  │  .github/  │  │
+│  │  (OS)    │  │  (GitOps)   │  │ (init)   │  │  (CI/CD)   │  │
+│  └──────────┘  └─────────────┘  └──────────┘  └────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+         │               │
+         ▼               ▼
+  ┌─────────────┐  ┌───────────────────────────────┐
+  │ Talos Linux │  │  Flux (in-cluster GitOps)     │
+  │  bare metal │  │  continuously reconciles       │
+  │  node       │  │  kubernetes/ from Git          │
+  └─────────────┘  └───────────────────────────────┘
+```
+
+______________________________________________________________________
+
+## Repository Layout
+
+```
+home-ops/
+├── talos/               # Talos OS node configuration
+├── kubernetes/          # All Kubernetes manifests (owned by Flux)
+│   ├── flux/            # Flux entrypoint Kustomization
+│   ├── apps/            # Namespaced application definitions
+│   └── components/      # Shared reusable Kustomize components
+├── bootstrap/           # One-time cluster bootstrap (Helmfile)
+├── docs/                # Project documentation
+├── scripts/             # Helper scripts
+├── templates/           # makejinja templates for config generation
+├── .github/             # GitHub Actions workflows, Renovate config, Copilot instructions
+├── .taskfiles/          # Task runner task definitions
+├── AGENTS.md            # Agent instructions (Copilot, Codex, Cursor, etc.)
+├── CLAUDE.md            # Claude Code entry point (references AGENTS.md)
+├── cluster.yaml         # Cluster-level configuration values
+├── nodes.yaml           # Node-level configuration values
+├── Taskfile.yaml        # Task runner entrypoint
+└── .mise.toml           # Tool version pinning (mise)
+```
+
+______________________________________________________________________
+
+## Layers
+
+### 1. OS Layer – Talos
+
+[Talos Linux](https://talos.dev/) is the immutable, API-driven OS running on the bare-metal
+node. Configuration is managed by [talhelper](https://github.com/budimanjojo/talhelper) using
+`talos/talconfig.yaml` which is rendered into per-node machine configs.
+
+Key files:
+
+| File                        | Purpose                                                 |
+| --------------------------- | ------------------------------------------------------- |
+| `talos/talconfig.yaml`      | Node definitions, IP config, Talos/Kubernetes versions  |
+| `talos/talenv.yaml`         | Version variables (`talosVersion`, `kubernetesVersion`) |
+| `talos/talsecret.sops.yaml` | Encrypted cluster PKI / join tokens                     |
+| `talos/patches/`            | Global and controller-specific Talos config patches     |
+| `talos/clusterconfig/`      | Generated output of `talhelper genconfig`               |
+
+The VIP (`192.168.1.145`) floats across control-plane nodes and is the stable API server address.
+
+Networking: pod CIDR `10.42.0.0/16`, service CIDR `10.43.0.0/16`. The built-in CNI is disabled
+in favor of Cilium.
+
+______________________________________________________________________
+
+### 2. Bootstrap Layer – Helmfile
+
+The `bootstrap/helmfile.d/` directory installs the minimum set of components required to get Flux
+running inside the cluster. This is a **one-time** operation (run via `task bootstrap:apps`).
+
+Bootstrap install order (each release `needs` the previous):
+
+1. **cilium** – CNI (networking)
+2. **coredns** – cluster DNS
+3. **cert-manager** – TLS certificate management
+4. **flux-operator** – installs the Flux operator
+5. **flux-instance** – creates a Flux `FluxInstance` pointing at this repo
+
+`bootstrap/helmfile.d/00-crds.yaml` is a separate helmfile used only to extract CRDs from charts
+that need them installed before the main bootstrap run.
+
+After bootstrap, Flux takes over and manages all further state from Git.
+
+______________________________________________________________________
+
+### 3. GitOps Layer – Flux
+
+Once bootstrapped, Flux continuously reconciles `kubernetes/` from the Git repository.
+
+#### Entrypoint
+
+`kubernetes/flux/cluster/ks.yaml` is the root `Kustomization` resource. It points Flux at
+`kubernetes/apps/` and applies global patches to every child `Kustomization` and `HelmRelease`
+(e.g. SOPS decryption, CRD install/upgrade strategy, rollback behavior).
+
+#### App structure
+
+Each application under `kubernetes/apps/` follows this pattern:
+
+```
+kubernetes/apps/<namespace>/
+├── kustomization.yaml      # namespace-level Kustomization pointing to child ks.yaml files
+├── namespace.yaml          # Namespace manifest
+└── <app-name>/
+    ├── ks.yaml             # Flux Kustomization for this app
+    └── app/
+        ├── kustomization.yaml
+        ├── helmrelease.yaml     # HelmRelease (Helm chart + values)
+        ├── ocirepository.yaml   # OCI source reference
+        └── *.sops.yaml          # Encrypted secrets (if any)
+```
+
+#### Namespaces
+
+| Namespace          | Contents                                                                       |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `kube-system`      | cilium, coredns, metrics-server, reloader                                      |
+| `cert-manager`     | cert-manager (TLS)                                                             |
+| `network`          | envoy-gateway, cloudflared tunnel, external-dns (k8s-gateway + cloudflare-dns) |
+| `external-secrets` | external-secrets operator, 1Password Connect                                   |
+| `flux-system`      | Flux itself                                                                    |
+| `default`          | General applications (e.g. `echo` test server)                                 |
+
+#### Shared components
+
+`kubernetes/components/sops/` is a reusable Kustomize component that injects the SOPS
+`cluster-secrets` `Secret` and decryption config into any `Kustomization` that references it.
+
+______________________________________________________________________
+
+### 4. Secrets – SOPS + age
+
+All secrets committed to Git are encrypted with SOPS using an age key. The `.sops.yaml` file
+defines encryption rules:
+
+- Files matching `talos/*.sops.yaml` → encrypt entire file
+- Files matching `(bootstrap|kubernetes)/*.sops.yaml` → encrypt only `data`/`stringData` fields
+
+The age public key is stored in `.sops.yaml`; the private key lives in `age.key` (gitignored) and
+is referenced by the `SOPS_AGE_KEY_FILE` environment variable.
+
+Flux decrypts secrets in-cluster using a `Secret` containing the age private key, configured via
+the SOPS decryption provider on each `Kustomization`.
+
+______________________________________________________________________
+
+### 5. Networking
+
+| Component                         | Role                                                               |
+| --------------------------------- | ------------------------------------------------------------------ |
+| **Cilium**                        | eBPF CNI, kube-proxy replacement, network policy                   |
+| **CoreDNS**                       | In-cluster DNS                                                     |
+| **Envoy Gateway**                 | Kubernetes Gateway API implementation (ingress/traffic routing)    |
+| **cloudflared**                   | Cloudflare Tunnel – exposes services externally without open ports |
+| **external-dns (k8s-gateway)**    | Internal DNS resolution for cluster services                       |
+| **external-dns (cloudflare-dns)** | Syncs DNS records to Cloudflare for external access                |
+
+______________________________________________________________________
+
+### 6. Certificate Management
+
+**cert-manager** issues TLS certificates for in-cluster services. It is bootstrapped via
+Helmfile and subsequently managed by Flux.
+
+______________________________________________________________________
+
+### 7. Dependency Updates – Renovate
+
+Renovate runs on a weekend schedule (`.renovaterc.json5`) and opens PRs to update:
+
+- Helm chart versions in `HelmRelease` manifests
+- Container image digests
+- OCI chart references
+- GitHub Actions versions
+- Tool versions in `.mise.toml`
+
+Annotated inline comments (`# renovate: datasource=...`) drive version tracking for values that
+Renovate cannot auto-detect. GitHub Actions minor/patch updates are auto-merged after 3 days.
+
+______________________________________________________________________
+
+### 8. CI – GitHub Actions
+
+| Workflow          | Trigger                                | Purpose                                                                                                            |
+| ----------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `flux-local.yaml` | PR to `main` (kubernetes/\*\* changes) | Validates Flux manifests with `flux-local test`; posts a diff of HelmRelease/Kustomization changes as a PR comment |
+| `renovate.yaml`   | Schedule + dispatch                    | Runs Renovate dependency updates                                                                                   |
+| `label-sync.yaml` | Push to `main`                         | Syncs GitHub labels from `labels.yaml`                                                                             |
+| `labeler.yaml`    | PR                                     | Auto-labels PRs based on changed paths                                                                             |
+| `release.yaml`    | Push to `main`                         | Creates GitHub releases                                                                                            |
+
+______________________________________________________________________
+
+### 9. Developer Tooling
+
+Tools are pinned in `.mise.toml` and managed by [mise](https://mise.jdx.dev/). Linting is handled
+by [pre-commit](https://pre-commit.com/) with hooks for YAML formatting (`yamlfmt`), Markdown
+formatting (`mdformat`), and whitespace. Common tasks are wrapped with
+[Task](https://taskfile.dev/) (`Taskfile.yaml` + `.taskfiles/`).
+
+Key tasks:
+
+| Task                         | Description                                                                 |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| `task bootstrap:talos`       | Apply Talos machine configs to nodes                                        |
+| `task bootstrap:apps`        | Run the Helmfile bootstrap (installs Flux)                                  |
+| `task talos:generate-config` | Render `talconfig.yaml` → node configs via talhelper                        |
+| `task reconcile`             | Force Flux to pull changes from Git immediately                             |
+| `task configure`             | Re-render cluster config from `cluster.yaml` / `nodes.yaml` templates       |
+| `task lint`                  | Run all pre-commit hooks (yamlfmt, mdformat, YAML checks) against all files |
+| `task dev:validate`          | Validate all Flux manifests offline via `flux-local` (no cluster needed)    |
+| `task dev:start`             | Redirect Flux to the current branch for live cluster testing                |
+| `task dev:stop`              | Restore Flux to `main` after branch testing                                 |
+
+Configuration values in `cluster.yaml` and `nodes.yaml` are rendered through
+[makejinja](https://github.com/mirkolenz/makejinja) (`makejinja.toml`) to generate the actual YAML
+manifests and Talos configs from the `templates/` directory.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -96,9 +96,13 @@ Defined in `.taskfiles/dev/Taskfile.yaml`. Enables testing changes against the l
 **Typical workflow:**
 
 ```bash
-# Create a worktree to isolate the feature branch
+# Create a worktree to isolate the feature branch (sibling of the main checkout)
 git worktree add ../home-ops-my-change -b feature/my-change
 cd ../home-ops-my-change
+
+# Symlink gitignored files required by dev tasks
+ln -s ../home-ops/age.key age.key
+ln -s ../home-ops/kubeconfig kubeconfig
 
 # edit kubernetes/ manifests ...
 task dev:start      # redirect Flux at this branch
@@ -107,7 +111,7 @@ task dev:sync       # push + reconcile after each change
 # done:
 task dev:stop       # restore Flux to main
 
-# Clean up
+# Clean up (must be run from outside the worktree)
 cd ../home-ops
 git worktree remove ../home-ops-my-change
 ```

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -100,7 +100,7 @@ Defined in `.taskfiles/dev/Taskfile.yaml`. Enables testing changes against the l
 git worktree add ../home-ops-my-change -b feature/my-change
 cd ../home-ops-my-change
 
-# Symlink gitignored files required by dev tasks
+# Symlink gitignored files required by dev tasks (Taskfile resolves these from ROOT_DIR)
 ln -s ../home-ops/age.key age.key
 ln -s ../home-ops/kubeconfig kubeconfig
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,140 @@
+# Tasks
+
+This project uses [Task](https://taskfile.dev/) as its task runner. Tasks are defined in
+`Taskfile.yaml` (root) and `.taskfiles/` (namespaced sub-taskfiles).
+
+Run `task` (or `task default`) to list all available tasks.
+
+______________________________________________________________________
+
+## Top-level Tasks
+
+These tasks are defined directly in `Taskfile.yaml`.
+
+| Task             | Description                                                                            |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| `task init`      | Initialize configuration files (age key, deploy key, push token, sample configs)       |
+| `task configure` | Render and validate all configuration files from `cluster.yaml` / `nodes.yaml`         |
+| `task lint`      | Run all pre-commit hooks against every file in the repo                                |
+| `task reconcile` | Force Flux to pull in changes from Git immediately                                     |
+| `task encrypt`   | Encrypt sensitive local files (cluster.yaml, kubeconfig, etc.) with SOPS to `secrets/` |
+| `task decrypt`   | Decrypt files from `secrets/` back to their original paths                             |
+
+______________________________________________________________________
+
+## `bootstrap:` — Cluster Bootstrap
+
+Defined in `.taskfiles/bootstrap/Taskfile.yaml`. Run once when standing up a new cluster.
+
+| Task                   | Description                                                                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `task bootstrap:talos` | Full Talos cluster bootstrap: generates secrets, renders configs, applies machine configs to nodes, bootstraps etcd, and downloads kubeconfig |
+| `task bootstrap:apps`  | Runs `scripts/bootstrap-apps.sh` to install core apps (Cilium → CoreDNS → cert-manager → Flux) via Helmfile                                   |
+
+**`bootstrap:talos` steps in order:**
+
+1. Generate cluster secrets (`talsecret.sops.yaml`) if not already present
+2. Render node configs via `talhelper genconfig`
+3. Apply configs to nodes with `--insecure` (pre-PKI)
+4. Bootstrap etcd (retries until ready)
+5. Download `kubeconfig` to the repo root
+
+**Prerequisites:** `.sops.yaml`, `age.key`, `talos/talconfig.yaml`, `talhelper`, `talosctl`, `sops`
+
+______________________________________________________________________
+
+## `talos:` — Talos Node Operations
+
+Defined in `.taskfiles/talos/Taskfile.yaml`. Used for day-2 operations on running nodes.
+
+| Task                              | Description                                                                                         |
+| --------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `task talos:generate-config`      | Re-render Talos node configs from `talconfig.yaml` via `talhelper genconfig`                        |
+| `task talos:apply-node IP=<ip>`   | Apply updated Talos config to a single node. Mode defaults to `auto` (can pass `MODE=reboot`, etc.) |
+| `task talos:upgrade-node IP=<ip>` | Upgrade Talos on a single node to the version defined in `talenv.yaml`                              |
+| `task talos:upgrade-k8s`          | Upgrade Kubernetes to the version defined in `talenv.yaml`                                          |
+| `task talos:reset`                | ⚠️ Resets all nodes back to maintenance mode (destroys the cluster)                                 |
+
+**Variable reference:**
+
+| Variable | Description                                                    |
+| -------- | -------------------------------------------------------------- |
+| `IP`     | Node IP address (required for `apply-node` and `upgrade-node`) |
+| `MODE`   | Talos apply mode for `apply-node` — defaults to `auto`         |
+
+______________________________________________________________________
+
+## `template:` — Template Lifecycle
+
+Defined in `.taskfiles/template/Taskfile.yaml`. Manages the initial config templating workflow
+and provides utilities inherited from the upstream
+[cluster-template](https://github.com/onedr0p/cluster-template).
+
+| Task                  | Description                                                                                                                      |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `task template:debug` | Print common cluster resources (`nodes`, `pods`, `helmreleases`, `kustomizations`, etc.) across all namespaces                   |
+| `task template:tidy`  | Archive template-related files (templates/, makejinja.toml, cluster.yaml, etc.) to `.private/` and clean up template scaffolding |
+| `task template:reset` | ⚠️ Remove all rendered directories (`bootstrap/`, `kubernetes/`, `talos/`, `.sops.yaml`)                                         |
+
+> `template:tidy` and `template:reset` are primarily used in the upstream template's CI/CD
+> (`e2e.yaml`) to clean up after end-to-end tests. Use with caution on a live cluster.
+
+______________________________________________________________________
+
+## `dev:` — Local Development / Branch Testing
+
+Defined in `.taskfiles/dev/Taskfile.yaml`. Enables testing changes against the live cluster
+**without pushing to `main`** by temporarily redirecting Flux to watch the current git branch.
+
+| Task                | Description                                                                                                                                              |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `task dev:validate` | Run `flux-local test` locally via Docker — validates all Helm renders and Kustomization builds with no cluster required                                  |
+| `task dev:start`    | Push current branch, suspend the `flux-instance` HelmRelease, patch the `flux-system` GitRepository to watch the current branch, and trigger a reconcile |
+| `task dev:sync`     | Push new commits on the current branch and trigger Flux to reconcile them                                                                                |
+| `task dev:stop`     | Restore the GitRepository to `refs/heads/main`, resume the `flux-instance` HelmRelease, and trigger a reconcile                                          |
+
+**Typical workflow:**
+
+```bash
+git checkout -b feature/my-change
+# edit kubernetes/ manifests ...
+task dev:start      # redirect Flux at this branch
+# iterate:
+task dev:sync       # push + reconcile after each change
+# done:
+task dev:stop       # restore Flux to main
+```
+
+> `dev:start` suspends the `flux-instance` HelmRelease so the flux-operator does not fight the
+> GitRepository patch. `dev:stop` resumes it and restores everything to the production state.
+> Neither `dev:start` nor `dev:sync` can be run on `main`.
+
+______________________________________________________________________
+
+## Internal / Sub-tasks
+
+The following tasks are called internally by `configure` and `init` and are not intended to be
+run directly:
+
+| Internal Task                | Called By   | Description                                                                     |
+| ---------------------------- | ----------- | ------------------------------------------------------------------------------- |
+| `validate-schemas`           | `configure` | Validates `cluster.yaml` and `nodes.yaml` against CUE schemas                   |
+| `render-configs`             | `configure` | Runs `makejinja` to render templates into actual YAML manifests                 |
+| `encrypt-secrets`            | `configure` | SOPS-encrypts all `*.sops.*` files in `bootstrap/`, `kubernetes/`, and `talos/` |
+| `validate-kubernetes-config` | `configure` | Runs `kubeconform` against the rendered Kubernetes manifests                    |
+| `validate-talos-config`      | `configure` | Validates `talconfig.yaml` with `talhelper validate talconfig`                  |
+| `generate-age-key`           | `init`      | Generates `age.key` if not present                                              |
+| `generate-deploy-key`        | `init`      | Generates `github-deploy.key` (ed25519 SSH key) if not present                  |
+| `generate-push-token`        | `init`      | Generates `github-push-token.txt` if not present                                |
+
+______________________________________________________________________
+
+## Environment Variables
+
+The following environment variables are set automatically by `Taskfile.yaml` and `.mise.toml`:
+
+| Variable            | Value                                         | Description                                            |
+| ------------------- | --------------------------------------------- | ------------------------------------------------------ |
+| `KUBECONFIG`        | `<repo-root>/kubeconfig`                      | Kubernetes config file used by `kubectl` and `flux`    |
+| `SOPS_AGE_KEY_FILE` | `<repo-root>/age.key`                         | Age private key used by SOPS for encryption/decryption |
+| `TALOSCONFIG`       | `<repo-root>/talos/clusterconfig/talosconfig` | Talos client config used by `talosctl`                 |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -96,13 +96,20 @@ Defined in `.taskfiles/dev/Taskfile.yaml`. Enables testing changes against the l
 **Typical workflow:**
 
 ```bash
-git checkout -b feature/my-change
+# Create a worktree to isolate the feature branch
+git worktree add ../home-ops-my-change -b feature/my-change
+cd ../home-ops-my-change
+
 # edit kubernetes/ manifests ...
 task dev:start      # redirect Flux at this branch
 # iterate:
 task dev:sync       # push + reconcile after each change
 # done:
 task dev:stop       # restore Flux to main
+
+# Clean up
+cd ../home-ops
+git worktree remove ../home-ops-my-change
 ```
 
 > `dev:start` suspends the `flux-instance` HelmRelease so the flux-operator does not fight the


### PR DESCRIPTION
## Summary

Adds comprehensive documentation and developer tooling for this repo, structured for both human contributors and AI coding agents.

### Agent Instructions
- **`AGENTS.md`** — fully rewritten as agent-first instructions: environment setup, validation sequence, dev rules, branch testing workflow, app pattern with doc update steps, CI description, and gotchas
- **`CLAUDE.md`** — Claude Code entry point via `@AGENTS.md`
- **`.github/copilot-instructions.md`** — Copilot Chat/review entry point linking to `AGENTS.md`

### Documentation
- **`docs/ARCHITECTURE.md`** — deep-dive covering all repo layers (Talos, Helmfile bootstrap, Flux GitOps, SOPS secrets, networking, cert-manager, Renovate, CI, developer tooling)
- **`docs/TASKS.md`** — full reference for every `task` command across all namespaces

### Developer Tooling
- **`.taskfiles/dev/Taskfile.yaml`** — new `dev:` task namespace for branch-based live cluster testing without pushing to `main`:
  - `task dev:validate` — offline Flux manifest validation via `flux-local` (no cluster needed)
  - `task dev:start` — redirects Flux to current branch (suspends `flux-instance` HelmRelease, patches `GitRepository`)
  - `task dev:sync` — push + reconcile on subsequent commits
  - `task dev:stop` — restores `flux-instance` and points cluster back at `main`
- **`task lint`** — added to root `Taskfile.yaml`, runs `pre-commit run --all-files`