### PR TITLE
🔦 headlamp: add headlamp dashboard with flux plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ ______________________________________________________________________
   testing.
 - **[headlamp](https://headlamp.dev/)**: Kubernetes dashboard with the
   [Flux plugin](https://github.com/headlamp-k8s/headlamp-plugin-flux) for GitOps visibility.
-  Available at `headlamp.${SECRET_DOMAIN}`.
 
 ## <img src="https://fonts.gstatic.com/s/e/notoemoji/latest/1f52e/512.gif" alt="🔮" width="20" height="20"> Hardware
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ ______________________________________________________________________
 
 - **[echo](https://github.com/mendhak/docker-http-https-echo)**: Simple HTTP/HTTPS echo server for
   testing.
+- **[headlamp](https://headlamp.dev/)**: Kubernetes dashboard with the
+  [Flux plugin](https://github.com/headlamp-k8s/headlamp-plugin-flux) for GitOps visibility.
+  Available at `headlamp.${SECRET_DOMAIN}`.
 
 ## <img src="https://fonts.gstatic.com/s/e/notoemoji/latest/1f52e/512.gif" alt="🔮" width="20" height="20"> Hardware
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -140,6 +140,7 @@ kubernetes/apps/<namespace>/
 | `external-secrets` | external-secrets operator, 1Password Connect                                   |
 | `flux-system`      | Flux itself                                                                    |
 | `default`          | General applications (e.g. `echo` test server)                                 |
+| `observability`    | headlamp Kubernetes dashboard with Flux plugin                                 |
 
 #### Shared components
 

--- a/kubernetes/apps/observability/headlamp/app/clusterrolebinding.yaml
+++ b/kubernetes/apps/observability/headlamp/app/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/clusterrolebinding_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: headlamp-admin
+    namespace: observability

--- a/kubernetes/apps/observability/headlamp/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/headlamp/app/externalsecret.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: headlamp-admin-token
+  namespace: observability
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: headlamp-admin-token
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: headlamp-admin-token

--- a/kubernetes/apps/observability/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/headlamp/app/helmrelease.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: headlamp
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.33.0
+  url: oci://ghcr.io/home-operations/charts-mirror/headlamp
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headlamp
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: headlamp
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+    fullnameOverride: headlamp
+    initContainers:
+      - image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.4.0@sha256:8d14174a166e2ccb2080a9f745b2ce8e19587ff8a2f41753eb1294875e650474
+        command:
+          - /bin/sh
+          - -c
+          - mkdir -p /build/plugins && cp -r /plugins/* /build/plugins/
+        name: headlamp-plugins
+        volumeMounts:
+          - mountPath: /build/plugins
+            name: headlamp-plugins
+    config:
+      pluginsDir: /build/plugins
+    serviceAccount:
+      create: false
+      name: headlamp-admin
+    clusterRoleBinding:
+      create: false
+    volumeMounts:
+      - mountPath: /build/plugins
+        name: headlamp-plugins
+    volumes:
+      - name: headlamp-plugins
+        emptyDir: {}

--- a/kubernetes/apps/observability/headlamp/app/httproute.yaml
+++ b/kubernetes/apps/observability/headlamp/app/httproute.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headlamp
+  namespace: observability
+spec:
+  hostnames: ["headlamp.${SECRET_DOMAIN}"]
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: headlamp
+          namespace: observability
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/observability/headlamp/app/kustomization.yaml
+++ b/kubernetes/apps/observability/headlamp/app/kustomization.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clusterrolebinding.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./serviceaccount.yaml

--- a/kubernetes/apps/observability/headlamp/app/serviceaccount.yaml
+++ b/kubernetes/apps/observability/headlamp/app/serviceaccount.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/core/serviceaccount_v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp-admin
+  namespace: observability

--- a/kubernetes/apps/observability/headlamp/ks.yaml
+++ b/kubernetes/apps/observability/headlamp/ks.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app headlamp
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/headlamp/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: observability
+components:
+  - ../../components/sops
+resources:
+  - ./namespace.yaml
+  - ./headlamp/ks.yaml

--- a/kubernetes/apps/observability/namespace.yaml
+++ b/kubernetes/apps/observability/namespace.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/core/namespace_v1.json
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/specs/002-headlamp-flux/checklists/requirements.md
+++ b/specs/002-headlamp-flux/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Headlamp + Flux Plugin
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-001 and FR-002 are already implemented on the existing `headlamp-app` branch. Remaining work is FR-003 through FR-007 (ServiceAccount, ClusterRoleBinding, ExternalSecret).
+- The "Existing Work" section in the spec captures the current state of the `headlamp-app` branch for implementer context.

--- a/specs/002-headlamp-flux/plan.md
+++ b/specs/002-headlamp-flux/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Headlamp + Flux Plugin
+
+**Branch**: `002-headlamp-flux` | **Date**: 2026-02-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-headlamp-flux/spec.md`
+
+## Summary
+
+Extend the partial Headlamp deployment on the `headlamp-app` branch with the four missing
+resources: `ServiceAccount`, `ClusterRoleBinding`, `ExternalSecret` (syncing
+`headlamp-admin-token` from 1Password), and a standalone `HTTPRoute` exposing Headlamp at
+`headlamp.${SECRET_DOMAIN}` via the `envoy-external` Gateway. The existing `ks.yaml` also
+requires a `postBuild.substituteFrom` addition for variable substitution to work.
+
+## Technical Context
+
+**Language/Version**: YAML / Kubernetes manifests (no application code)
+**Primary Dependencies**: Flux v2, External Secrets Operator v1, Headlamp Helm chart v0.33.0, Gateway API (HTTPRoute), 1Password Connect
+**Storage**: N/A
+**Testing**: `task lint` (yamlfmt auto-fix), `task dev:validate` (flux-local offline render)
+**Target Platform**: Talos Linux / Kubernetes homelab cluster (single-node or multi-node)
+**Project Type**: GitOps manifest additions — no src/ tree
+**Performance Goals**: Headlamp UI loads within 10 seconds of navigation (SC-001)
+**Constraints**: GitOps-only (no `kubectl apply`); all secrets via SOPS or ExternalSecret; `envoy-external` Gateway for HTTPS ingress
+**Scale/Scope**: Single homelab cluster, single operator user
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle                          | Status                 | Notes                                                                                             |
+| ---------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------- |
+| I — GitOps & Declarative           | ✅ Pass                | All resources reconciled by Flux; no out-of-band applies                                          |
+| II — IaC & Reproducibility         | ✅ Pass                | All manifests committed; no undocumented manual steps                                             |
+| III — Template & Bootstrappability | ✅ Pass                | Follows existing patterns; no new external dependencies                                           |
+| IV — Modular Architecture          | ✅ Pass                | Isolated in `observability/headlamp/`; independently disable-able via ks.yaml                     |
+| V — Code Quality                   | ✅ Pass                | Consistent naming conventions matching existing apps                                              |
+| VI — DRY                           | ✅ Pass                | Reuses `onepassword` ClusterSecretStore, `envoy-external` Gateway, `cluster-secrets` substitution |
+| VII — Observability                | ✅ Pass                | Headlamp + Flux plugin IS the observability layer                                                 |
+| VIII — Security & Least Privilege  | ⚠️ Justified Exception | `cluster-admin` violates least privilege — see Complexity Tracking                                |
+| IX — Testing & Validation          | ✅ Pass                | `task lint` + `task dev:validate` validates all manifests offline                                 |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-headlamp-flux/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+kubernetes/apps/observability/
+├── kustomization.yaml                        # EXISTING — already references headlamp/ks.yaml
+└── headlamp/
+    ├── ks.yaml                               # UPDATE — add postBuild.substituteFrom
+    └── app/
+        ├── kustomization.yaml                # UPDATE — add all new resource files
+        ├── helmrelease.yaml                  # EXISTING — no changes needed
+        ├── serviceaccount.yaml               # NEW
+        ├── clusterrolebinding.yaml           # NEW
+        ├── externalsecret.yaml               # NEW
+        └── httproute.yaml                    # NEW
+```
+
+**Structure Decision**: Manifest-only GitOps additions. No src/ tree. All new files follow
+the existing pattern in `kubernetes/apps/observability/headlamp/app/`. Reference app:
+`kubernetes/apps/default/echo/` and `kubernetes/apps/flux-system/flux-instance/`.
+
+## Complexity Tracking
+
+| Violation                                                                    | Why Needed                                                                                             | Simpler Alternative Rejected Because                                                                                                                                      |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cluster-admin` ClusterRoleBinding (violates Principle VIII least-privilege) | Homelab dashboard must display all resources including Secrets, CustomResources, and system namespaces | The built-in `view` ClusterRole hides Secrets entirely; a custom read-all ClusterRole would need to enumerate every API group and is fragile against new CRDs being added |

--- a/specs/002-headlamp-flux/quickstart.md
+++ b/specs/002-headlamp-flux/quickstart.md
@@ -162,6 +162,13 @@ task dev:validate   # offline render of all HelmReleases and Kustomizations
 ## Accessing Headlamp
 
 1. Navigate to `https://headlamp.${SECRET_DOMAIN}` (e.g., `https://headlamp.juftin.dev`)
-2. Retrieve the token from 1Password under **headlamp-admin-token → password field**
+2. Retrieve the token from 1Password under **headlamp-admin-token → password field** (this is the
+   Kubernetes ServiceAccount JWT, not a traditional password — the Login item type is used so
+   1Password can autofill it when visiting the URL)
 3. Paste the token into the Headlamp login screen
 4. Navigate to the **Flux** section in the sidebar to view GitOps resource status
+
+> [!NOTE]
+> The token is generated with `kubectl create token headlamp-admin -n observability --duration=8760h`
+> (1-year TTL). If authentication fails, the stored token may be stale — regenerate it and update
+> the 1Password item: `op item edit "headlamp-admin-token" "password=$(kubectl create token headlamp-admin -n observability --duration=8760h)"`

--- a/specs/002-headlamp-flux/quickstart.md
+++ b/specs/002-headlamp-flux/quickstart.md
@@ -1,0 +1,167 @@
+# Quickstart: Headlamp + Flux Plugin
+
+This guide describes the files to create/update to complete the Headlamp deployment. The
+`headlamp-app` branch already has the OCIRepository, HelmRelease, and namespace-level
+Kustomization. This guide covers the missing pieces.
+
+______________________________________________________________________
+
+## Prerequisites
+
+- The `headlamp-app` branch work is merged or cherry-picked into `002-headlamp-flux`
+- External Secrets Operator is running with `ClusterSecretStore/onepassword` in `Ready` state
+- The `headlamp-admin-token` item exists in the 1Password **homelab** vault as a Password-type item
+- The `envoy-external` Gateway is running in the `network` namespace
+
+______________________________________________________________________
+
+## Files to Create
+
+### 1. `kubernetes/apps/observability/headlamp/app/serviceaccount.yaml`
+
+```yaml
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/core/serviceaccount_v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp-admin
+  namespace: observability
+```
+
+### 2. `kubernetes/apps/observability/headlamp/app/clusterrolebinding.yaml`
+
+```yaml
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/clusterrolebinding_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: headlamp-admin
+    namespace: observability
+```
+
+### 3. `kubernetes/apps/observability/headlamp/app/externalsecret.yaml`
+
+```yaml
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: headlamp-admin-token
+  namespace: observability
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: headlamp-admin-token
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: headlamp-admin-token
+```
+
+> [!NOTE]
+> This uses `dataFrom.extract` to pull all fields from the `headlamp-admin-token`
+> 1Password item into a single Kubernetes secret. If only the `password` field is needed,
+> replace with `data[0].remoteRef: {key: headlamp-admin-token, property: password}`.
+
+### 4. `kubernetes/apps/observability/headlamp/app/httproute.yaml`
+
+```yaml
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headlamp
+  namespace: observability
+spec:
+  hostnames: ['headlamp.${SECRET_DOMAIN}']
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: headlamp
+          namespace: observability
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+```
+
+______________________________________________________________________
+
+## Files to Update
+
+### 5. `kubernetes/apps/observability/headlamp/app/kustomization.yaml`
+
+Add all new resource files:
+
+```yaml
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clusterrolebinding.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./serviceaccount.yaml
+```
+
+### 6. `kubernetes/apps/observability/headlamp/ks.yaml`
+
+Add `postBuild.substituteFrom` so `${SECRET_DOMAIN}` is substituted in the HTTPRoute hostname:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app headlamp
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/headlamp/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+```
+
+______________________________________________________________________
+
+## Validate
+
+```bash
+task lint           # auto-fix YAML formatting
+task dev:validate   # offline render of all HelmReleases and Kustomizations
+```
+
+## Accessing Headlamp
+
+1. Navigate to `https://headlamp.${SECRET_DOMAIN}` (e.g., `https://headlamp.juftin.dev`)
+2. Retrieve the token from 1Password under **headlamp-admin-token → password field**
+3. Paste the token into the Headlamp login screen
+4. Navigate to the **Flux** section in the sidebar to view GitOps resource status

--- a/specs/002-headlamp-flux/research.md
+++ b/specs/002-headlamp-flux/research.md
@@ -1,0 +1,68 @@
+# Research: Headlamp + Flux Plugin
+
+**Feature**: 002-headlamp-flux | **Date**: 2026-02-21
+
+## Resolved Unknowns
+
+### 1. Headlamp Service Name and Port
+
+- **Decision**: Service name `headlamp` (from `fullnameOverride: headlamp`), port `80`
+- **Rationale**: Headlamp chart exposes an HTTP service on port 80 by default, which forwards to the container port 4466. The `fullnameOverride` in the HelmRelease values sets the service name to `headlamp`.
+- **Impact**: The `HTTPRoute` backendRef must specify `name: headlamp` and `port: 80`.
+
+### 2. HTTPRoute Pattern
+
+- **Decision**: Standalone `httproute.yaml` manifest (not embedded in HelmRelease values)
+- **Rationale**: Headlamp uses the native headlamp Helm chart (not `app-template`), which does not have built-in `route:` support in its values. The `flux-instance` app uses the same standalone approach.
+- **Alternatives considered**: Embedding route in HelmRelease values (only possible with `app-template` chart); Ingress resource (Gateway API HTTPRoute is the cluster standard).
+- **Impact**: A separate `httproute.yaml` file is needed; echo app's embedded pattern does not apply.
+
+### 3. Flux Variable Substitution for `${SECRET_DOMAIN}`
+
+- **Decision**: `ks.yaml` must add `postBuild.substituteFrom` referencing the `cluster-secrets` Secret
+- **Rationale**: The HTTPRoute hostname uses `${SECRET_DOMAIN}`. Flux performs this substitution at reconcile time via `postBuild.substituteFrom`. The existing `headlamp-app` branch `ks.yaml` is missing this block. Reference: echo's `ks.yaml` which already has the correct pattern.
+- **Impact**: Without this addition, the HTTPRoute hostname would render as the literal string `headlamp.${SECRET_DOMAIN}` rather than `headlamp.juftin.dev`.
+
+### 4. ExternalSecret — 1Password Field Name
+
+- **Decision**: Field name `password` for the `headlamp-admin-token` 1Password item
+- **Rationale**: The user confirmed this is an "existing password" item in 1Password, making it a Password-type item. The primary secret field in a 1Password Password item is `password`. The project's naming convention (per `specs/001-external-secrets-1password/quickstart.md`) uses `SCREAMING_SNAKE_CASE` for custom fields on Secure Note items, but standard Password items use `password` as the field name.
+- **Alternatives considered**: Custom field with a different name — possible if the item was created with a custom field label, but `password` is the correct default for a Password-type item.
+- **Impact**: `ExternalSecret` `remoteRef.property` must be set to `password`. If the actual field name differs, this is the one value to update.
+
+### 5. ExternalSecret — ClusterSecretStore Name
+
+- **Decision**: `onepassword` (confirmed from existing cluster config)
+- **Rationale**: `kubernetes/apps/external-secrets/onepassword/app/clustersecretstore.yaml` defines `metadata.name: onepassword` pointing to 1Password Connect in the `external-secrets` namespace. This is the store used by all existing ExternalSecrets in the cluster.
+- **Impact**: `ExternalSecret` `spec.secretStoreRef.name` must be `onepassword` with `kind: ClusterSecretStore`.
+
+### 6. Namespace for All Resources
+
+- **Decision**: `observability` for all new resources (ServiceAccount, ClusterRoleBinding subject namespace, ExternalSecret)
+- **Rationale**: The existing `headlamp-app` branch deploys Headlamp into the `observability` namespace. All associated resources must be in the same namespace for the ServiceAccount reference to work. The `ClusterRoleBinding` is cluster-scoped but references the `headlamp-admin` SA in the `observability` namespace.
+- **Impact**: All manifests set `namespace: observability`.
+
+### 7. RBAC — ClusterRoleBinding vs RoleBinding
+
+- **Decision**: `ClusterRoleBinding` (cluster-scoped)
+- **Rationale**: Headlamp needs visibility across all namespaces for the dashboard to be useful. A `RoleBinding` would restrict visibility to a single namespace. User explicitly chose `cluster-admin` access.
+- **Alternatives considered**: `RoleBinding` to `view` in each namespace — rejected because Headlamp dashboard needs cross-namespace visibility and secret access.
+- **Impact**: A `ClusterRoleBinding` resource (not namespaced) is required.
+
+## Implementation Decisions Summary
+
+| Area                   | Decision                                                                |
+| ---------------------- | ----------------------------------------------------------------------- |
+| Headlamp service name  | `headlamp`                                                              |
+| Headlamp service port  | `80`                                                                    |
+| HTTPRoute pattern      | Standalone `httproute.yaml`                                             |
+| Gateway                | `envoy-external` in `network` namespace, section `https`                |
+| Hostname               | `headlamp.${SECRET_DOMAIN}` (substituted by Flux)                       |
+| ClusterSecretStore     | `onepassword`                                                           |
+| 1Password item         | `headlamp-admin-token`                                                  |
+| 1Password field        | `password`                                                              |
+| Target K8s secret name | `headlamp-admin-token` (matches item name, consistent with convention)  |
+| ServiceAccount         | `headlamp-admin` in `observability`                                     |
+| ClusterRole            | `cluster-admin` (justified exception — see plan.md Complexity Tracking) |
+| Namespace              | `observability`                                                         |
+| Variable substitution  | `postBuild.substituteFrom: cluster-secrets` in `ks.yaml`                |

--- a/specs/002-headlamp-flux/spec.md
+++ b/specs/002-headlamp-flux/spec.md
@@ -1,0 +1,124 @@
+# Feature Specification: Headlamp + Flux Plugin
+
+**Feature Branch**: `002-headlamp-flux`
+**Created**: 2026-02-21
+**Status**: Draft
+**Input**: User description: "I want to visualize my cluster and what flux is doing with headlamp and the flux plugin for headlamp. The credentials should be synced to 1Password. There is an existing password there called headlamp-admin-token"
+
+## Existing Work (headlamp-app branch)
+
+The `headlamp-app` branch contains a partial implementation:
+
+- `kubernetes/apps/observability/headlamp/app/helmrelease.yaml` — OCIRepository + HelmRelease deploying Headlamp chart v0.33.0 into the `observability` namespace; Flux plugin loaded via init container (`ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.4.0`); chart configured with `serviceAccount.create: false` and `clusterRoleBinding.create: false` (both expected to be pre-created).
+- `kubernetes/apps/observability/headlamp/app/kustomization.yaml` — references only `helmrelease.yaml`; no ExternalSecret yet.
+- `kubernetes/apps/observability/headlamp/ks.yaml` — Flux Kustomization targeting the `observability` namespace.
+- `kubernetes/apps/observability/kustomization.yaml` — namespace-level kustomization referencing headlamp's `ks.yaml`.
+
+**What is missing** from the existing branch:
+
+1. A `ServiceAccount` named `headlamp-admin` in the `observability` namespace.
+2. A `ClusterRoleBinding` granting `headlamp-admin` cluster-wide read access.
+3. An `ExternalSecret` syncing the `headlamp-admin-token` item from 1Password into a Kubernetes secret.
+
+## Clarifications
+
+### Session 2026-02-21
+
+- Q: What access level should the `headlamp-admin` ClusterRoleBinding grant? → A: `cluster-admin` (full read/write access to all resources including secrets)
+- Q: How should Headlamp be accessed? → A: Exposed externally at `headlamp.${SECRET_DOMAIN}` via HTTPRoute (Gateway API)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Access Cluster Dashboard (Priority: P1)
+
+As a cluster operator, I want to open Headlamp in a browser and see an overview of my Kubernetes cluster — namespaces, workloads, pods, and their statuses — so that I can understand the health of my homelab at a glance.
+
+**Why this priority**: Core value of the feature; everything else depends on Headlamp being accessible and functional.
+
+**Independent Test**: Can be fully tested by navigating to the Headlamp URL, logging in with the admin token sourced from 1Password, and verifying that the cluster resource list renders.
+
+**Acceptance Scenarios**:
+
+1. **Given** Headlamp is deployed and the admin token is synced from 1Password, **When** I open the Headlamp URL, **Then** I can authenticate and see the cluster's namespaces and workloads.
+2. **Given** I am logged in to Headlamp, **When** I click on any namespace, **Then** I see a list of pods and their current status.
+3. **Given** the admin token rotates in 1Password, **When** the secret is re-synced, **Then** Headlamp continues to work without manual intervention.
+
+______________________________________________________________________
+
+### User Story 2 - Visualize Flux GitOps State (Priority: P2)
+
+As a cluster operator, I want to see the state of all Flux resources — Kustomizations, HelmReleases, GitRepositories, and their sync status — inside Headlamp via the Flux plugin, so that I can quickly identify reconciliation failures or drift.
+
+**Why this priority**: The Flux plugin is the primary differentiator over a plain Kubernetes dashboard and delivers the core GitOps observability value.
+
+**Independent Test**: Can be fully tested by navigating to the Flux section in Headlamp and verifying that HelmReleases and Kustomizations appear with their current ready/failed status.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Flux plugin is installed in Headlamp, **When** I open the Flux section, **Then** I see all Kustomizations and HelmReleases with their sync status.
+2. **Given** a HelmRelease is failing, **When** I click on it in Headlamp, **Then** I can see the failure reason and last reconcile attempt.
+3. **Given** a Kustomization is suspended, **When** I view it in Headlamp, **Then** it is clearly marked as suspended.
+
+______________________________________________________________________
+
+### User Story 3 - Credentials Available via 1Password (Priority: P3)
+
+As a cluster operator, I want the Headlamp admin token to be automatically pulled from 1Password (the `headlamp-admin-token` item) into the cluster as a Kubernetes secret, so that I never need to manage it manually and it stays in sync with the authoritative source.
+
+**Why this priority**: Supports security hygiene and operational simplicity; Headlamp is still accessible without this if credentials are managed manually, making it lower priority than the dashboard itself.
+
+**Independent Test**: Can be fully tested by verifying that the Kubernetes secret containing the admin token exists and matches the value stored in 1Password under `headlamp-admin-token`, without any manual secret creation step.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ExternalSecret is configured pointing to the `headlamp-admin-token` 1Password item, **When** the secret is reconciled, **Then** a Kubernetes secret containing the token exists in the Headlamp namespace.
+2. **Given** the value of `headlamp-admin-token` changes in 1Password, **When** the ExternalSecret is next reconciled, **Then** the in-cluster secret is updated automatically.
+
+______________________________________________________________________
+
+### Edge Cases
+
+- What happens when the `headlamp-admin-token` item does not exist in 1Password or the ExternalSecret cannot fetch it? The Headlamp pod should still start, but login will fail until the secret is available.
+- What happens when Headlamp loses connectivity to the cluster API? The UI should display a clear error state rather than a blank screen.
+- What happens if the Flux plugin version is incompatible with the installed Flux version? The plugin section should degrade gracefully without breaking the core Headlamp UI.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: ✅ Headlamp MUST be deployed to the `observability` namespace and managed by Flux (OCIRepository + HelmRelease). *(Exists on headlamp-app branch)*
+- **FR-002**: ✅ The Flux plugin MUST be installed in Headlamp so that Flux resources (Kustomizations, HelmReleases, GitRepositories, OCI repositories) are visible and navigable. *(Implemented via init container on headlamp-app branch)*
+- **FR-003**: A `ServiceAccount` named `headlamp-admin` MUST exist in the `observability` namespace for Headlamp to use as its cluster identity.
+- **FR-004**: A `ClusterRoleBinding` MUST bind the `headlamp-admin` ServiceAccount to the `cluster-admin` ClusterRole, granting full access to all cluster resources including secrets.
+- **FR-005**: An `ExternalSecret` MUST sync the `headlamp-admin-token` item from 1Password into a Kubernetes secret in the `observability` namespace.
+- **FR-006**: The Headlamp HelmRelease MUST reference the synced secret (or ServiceAccount token) as the authentication credential for login.
+- **FR-007**: The `app/kustomization.yaml` MUST be updated to include all new resources (ExternalSecret, ServiceAccount, ClusterRoleBinding, HTTPRoute) so Flux reconciles them.
+- **FR-008**: An HTTPRoute MUST expose Headlamp externally at `headlamp.${SECRET_DOMAIN}` via the `envoy-external` Gateway in the `network` namespace over HTTPS.
+
+### Key Entities
+
+- **Headlamp HelmRelease**: Deploys the Headlamp web dashboard; configured with `serviceAccount.create: false` and `clusterRoleBinding.create: false`, expecting both to be pre-created.
+- **headlamp-admin ServiceAccount**: The Kubernetes identity used by Headlamp to communicate with the cluster API; must exist before Headlamp starts.
+- **ClusterRoleBinding**: Binds `headlamp-admin` to the `cluster-admin` ClusterRole, granting full access to all cluster resources including secrets.
+- **ExternalSecret**: Instructs External Secrets Operator to fetch `headlamp-admin-token` from 1Password and write it as a Kubernetes secret in the `observability` namespace.
+- **Admin Token Secret**: The resulting Kubernetes secret containing the bearer token used to log in to the Headlamp UI.
+- **HTTPRoute**: Gateway API resource routing `headlamp.${SECRET_DOMAIN}` to the Headlamp service via the `envoy-external` Gateway over HTTPS.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A cluster operator can open `https://headlamp.${SECRET_DOMAIN}`, authenticate with the token from 1Password, and view all cluster namespaces within 10 seconds of page load.
+- **SC-002**: All Flux Kustomizations and HelmReleases are visible in the Headlamp Flux plugin view with their current sync status.
+- **SC-003**: The admin token secret exists in the cluster and reflects the current value in 1Password within the ExternalSecret refresh interval (≤1 hour by default).
+- **SC-004**: No manual secret creation steps are required after the initial Flux deployment reconciles.
+- **SC-005**: Headlamp continues operating normally after the admin token is rotated in 1Password and the ExternalSecret re-syncs.
+
+## Assumptions
+
+- The External Secrets Operator is already installed and configured with a 1Password ClusterSecretStore in this cluster.
+- The `headlamp-admin-token` item already exists in 1Password with the correct token value.
+- Headlamp is exposed externally at `headlamp.${SECRET_DOMAIN}` via HTTPRoute through the `envoy-external` Gateway (consistent with other apps in this cluster such as `flux-webhook`); port-forwarding is not required.
+- Headlamp is deployed in the `observability` namespace, consistent with the existing `headlamp-app` branch.
+- The `headlamp-admin` ServiceAccount will use the token from the synced secret (or a separately created ServiceAccount token) as the Headlamp login credential.
+- The Flux plugin is already handled via the init container approach on the existing branch; no changes needed there.

--- a/specs/002-headlamp-flux/tasks.md
+++ b/specs/002-headlamp-flux/tasks.md
@@ -1,0 +1,178 @@
+______________________________________________________________________
+
+# Tasks: Headlamp + Flux Plugin
+
+**Input**: Design documents from `/specs/002-headlamp-flux/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, quickstart.md ✅
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and
+testing of each story. No tests requested — implementation tasks only.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+______________________________________________________________________
+
+## Phase 1: Setup (Bring in Existing Work)
+
+**Purpose**: Establish the starting point by merging the existing `headlamp-app` branch
+manifests into the `002-headlamp-flux` feature branch.
+
+- [ ] T001 Cherry-pick or copy existing headlamp manifests from `origin/headlamp-app` into `002-headlamp-flux` — files needed: `kubernetes/apps/observability/headlamp/app/helmrelease.yaml`, `kubernetes/apps/observability/headlamp/app/kustomization.yaml`, `kubernetes/apps/observability/headlamp/ks.yaml`, `kubernetes/apps/observability/kustomization.yaml`
+
+**Checkpoint**: Existing HelmRelease, OCIRepository, and Flux Kustomization are present on the
+feature branch and `task dev:validate` renders them without error.
+
+______________________________________________________________________
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Create the RBAC resources that Headlamp requires before its pod can start.
+The HelmRelease is configured with `serviceAccount.create: false` and
+`clusterRoleBinding.create: false` — both must exist before Flux reconciles Headlamp.
+
+**⚠️ CRITICAL**: Headlamp pod will crash-loop without these resources.
+
+- [ ] T002 [P] Create ServiceAccount manifest at `kubernetes/apps/observability/headlamp/app/serviceaccount.yaml` — name: `headlamp-admin`, namespace: `observability`
+- [ ] T003 [P] Create ClusterRoleBinding manifest at `kubernetes/apps/observability/headlamp/app/clusterrolebinding.yaml` — bind `headlamp-admin` ServiceAccount (in `observability`) to `cluster-admin` ClusterRole
+
+**Checkpoint**: Both RBAC manifests exist and are syntactically valid YAML.
+
+______________________________________________________________________
+
+## Phase 3: User Story 1 — Access Cluster Dashboard (Priority: P1) 🎯 MVP
+
+**Goal**: Headlamp is accessible at `https://headlamp.${SECRET_DOMAIN}` and a cluster
+operator can log in with the admin token to browse cluster resources.
+
+**Independent Test**: Navigate to `https://headlamp.juftin.dev`, paste the token from
+1Password (`headlamp-admin-token → password field`), and verify that all cluster namespaces
+and workloads are visible.
+
+- [ ] T004 [P] [US1] Create HTTPRoute manifest at `kubernetes/apps/observability/headlamp/app/httproute.yaml` — hostname: `headlamp.${SECRET_DOMAIN}`, parentRef: `envoy-external` in `network` namespace, section: `https`, backendRef: service `headlamp` port `80`
+- [ ] T005 [P] [US1] Update `kubernetes/apps/observability/headlamp/ks.yaml` — add `postBuild.substituteFrom` block referencing `cluster-secrets` Secret (required for `${SECRET_DOMAIN}` variable substitution in HTTPRoute hostname)
+- [ ] T006 [US1] Update `kubernetes/apps/observability/headlamp/app/kustomization.yaml` — add `serviceaccount.yaml`, `clusterrolebinding.yaml`, and `httproute.yaml` to the `resources:` list (depends on T002, T003, T004)
+
+**Checkpoint**: `task lint && task dev:validate` pass. US1 is fully deliverable: RBAC +
+HTTPRoute + variable substitution are all in place.
+
+______________________________________________________________________
+
+## Phase 4: User Story 2 — Visualize Flux GitOps State (Priority: P2)
+
+**Goal**: The Flux plugin surfaces Kustomizations, HelmReleases, GitRepositories, and their
+sync/failure status inside Headlamp.
+
+**Independent Test**: After logging in to Headlamp, open the Flux section and confirm all
+Kustomizations and HelmReleases are listed with their current ready/failed status.
+
+- [ ] T007 [US2] Review and confirm Flux plugin init container in `kubernetes/apps/observability/headlamp/app/helmrelease.yaml` — verify image `ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.4.0` with digest is present, `config.pluginsDir: /build/plugins` is set, and volume mounts are correct; update image tag/digest if a newer stable release is available
+
+**Checkpoint**: The init container configuration is confirmed correct. No additional manifests
+needed — the Flux plugin is fully implemented by the existing HelmRelease values.
+
+______________________________________________________________________
+
+## Phase 5: User Story 3 — Credentials Available via 1Password (Priority: P3)
+
+**Goal**: The `headlamp-admin-token` item from 1Password is automatically synced into a
+Kubernetes Secret in the `observability` namespace via ExternalSecret, so no manual secret
+management is needed after initial deployment.
+
+**Independent Test**: After Flux reconciles, `kubectl get secret headlamp-admin-token -n observability`
+exists and its `password` field matches the value stored in 1Password under `headlamp-admin-token`.
+
+- [ ] T008 [US3] Create ExternalSecret manifest at `kubernetes/apps/observability/headlamp/app/externalsecret.yaml` — secretStoreRef: `onepassword` (ClusterSecretStore), target secret name: `headlamp-admin-token`, dataFrom.extract.key: `headlamp-admin-token`
+- [ ] T009 [US3] Update `kubernetes/apps/observability/headlamp/app/kustomization.yaml` — add `externalsecret.yaml` to the `resources:` list (depends on T008)
+
+**Checkpoint**: All three user stories are independently functional. `task dev:validate`
+renders all resources without error.
+
+______________________________________________________________________
+
+## Final Phase: Polish & Validation
+
+**Purpose**: Formatting, offline validation, and PR preparation.
+
+- [ ] T010 Run `task lint` to auto-fix YAML formatting across all new and modified files (run twice if first pass reports hook failures — second pass always succeeds)
+- [ ] T011 Run `task dev:validate` to confirm offline rendering of all Flux HelmReleases and Kustomizations succeeds with no errors
+- [ ] T012 Commit all changes with emoji prefix (e.g., `🔦 headlamp`) and push branch `002-headlamp-flux` to `origin`
+- [ ] T013 Open pull request from `002-headlamp-flux` targeting `main` — include summary of new files and the `cluster-admin` justification from plan.md
+
+______________________________________________________________________
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on T001 — blocks US1 pod startup
+- **US1 (Phase 3)**: Depends on T002, T003 — HTTPRoute and ks.yaml update can start in parallel with Foundational
+- **US2 (Phase 4)**: Depends on T001 only — review can happen any time after setup
+- **US3 (Phase 5)**: Independent of US1/US2 — can start after T001
+- **Polish (Final)**: Depends on T006, T007, T009
+
+### User Story Dependencies
+
+- **US1 (P1)**: Requires Foundational (T002, T003) + T004, T005, T006
+- **US2 (P2)**: Requires T001 only — purely a review/confirm task
+- **US3 (P3)**: Requires T001 only — independent of US1 and US2
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel (different files)
+- T004 and T005 can run in parallel (different files)
+- T007 can run in parallel with any phase after T001
+- T008 can run in parallel with Phase 3 tasks (different file)
+
+______________________________________________________________________
+
+## Parallel Example: US1 + US3 Simultaneously
+
+```bash
+# After T001 completes, all of these can launch together:
+Task A: "Create serviceaccount.yaml"                   # T002
+Task B: "Create clusterrolebinding.yaml"               # T003
+Task C: "Create httproute.yaml"                        # T004
+Task D: "Update ks.yaml with postBuild.substituteFrom" # T005
+Task E: "Create externalsecret.yaml"                   # T008
+
+# Once T002, T003, T004 complete:
+Task F: "Update kustomization.yaml (SA + CRB + HTTPRoute)" # T006
+
+# Once T008 completes:
+Task G: "Update kustomization.yaml (add ExternalSecret)"   # T009
+```
+
+______________________________________________________________________
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Cherry-pick existing work (T001)
+2. Complete Phase 2: RBAC — ServiceAccount + ClusterRoleBinding (T002, T003)
+3. Complete Phase 3: HTTPRoute + ks.yaml update + kustomization update (T004–T006)
+4. **STOP and VALIDATE**: `task lint && task dev:validate`
+5. Headlamp is accessible at `https://headlamp.juftin.dev` ✅
+
+### Incremental Delivery
+
+1. T001 → T002/T003 → T004/T005 → T006 → **MVP: Headlamp accessible with full cluster RBAC**
+2. T007 → **US2: Flux plugin confirmed working** (no new manifests needed)
+3. T008 → T009 → **US3: Credentials auto-synced from 1Password**
+4. T010 → T011 → T012 → T013 → **PR merged, Flux reconciles on main**
+
+______________________________________________________________________
+
+## Notes
+
+- [P] tasks operate on different files — safe to run in parallel
+- `task lint` auto-fixes YAML formatting with `yamlfmt` — always run before committing
+- `task dev:validate` renders all Flux resources offline — no cluster access required
+- The `cluster-admin` ClusterRoleBinding is a documented justified exception (see plan.md Complexity Tracking)
+- If the 1Password field name for `headlamp-admin-token` differs from `password`, update the ExternalSecret `remoteRef.property` accordingly
+- The `postBuild.substituteFrom` addition to `ks.yaml` (T005) is critical — without it `${SECRET_DOMAIN}` renders literally in the HTTPRoute hostname


### PR DESCRIPTION
## Summary

Adds [Headlamp](https://headlamp.dev/) Kubernetes dashboard to the cluster with the [Flux plugin](https://github.com/headlamp-k8s/headlamp-plugin-flux) for GitOps visibility.

## What's included

- **Headlamp HelmRelease** (v0.33.0) in the `observability` namespace
- **Flux plugin** loaded via init container (`headlamp-plugin-flux:v0.4.0`) for visualizing Flux resources
- **HTTPRoute** exposing headlamp at `headlamp.${SECRET_DOMAIN}` via `envoy-external` gateway
- **cluster-admin ServiceAccount** (`headlamp-admin`) for full cluster visibility
- **ExternalSecret** syncing `headlamp-admin-token` from 1Password via `onepassword` ClusterSecretStore
- **Observability namespace** manifest with sops component

## Spec

`specs/002-headlamp-flux/` contains the full spec, plan, and research notes.

## Validation

- `task lint` ✅
- `task dev:validate` ✅ (`observability/headlamp` HelmRelease renders cleanly)