### PR TITLE
🚨 Fix Alertmanager routing and disable KubeProxyDown

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -17,6 +17,9 @@ spec:
       retries: 3
   values:
     fullnameOverride: kube-prometheus-stack
+    defaultRules:
+      disabled:
+        KubeProxyDown: true
     prometheus:
       prometheusSpec:
         scrapeInterval: 30s

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -66,6 +66,7 @@ spec:
           group_wait: 30s
           group_interval: 5m
           repeat_interval: 4h
+          routes: []
         receivers:
           - name: slack
             slack_configs:


### PR DESCRIPTION
## Summary
- fix Alertmanager route config by setting routes: [] so a missing default receiver no longer breaks reconciliation
- disable noisy KubeProxyDown default rule for Cilium kube-proxy replacement clusters
- validated by reconciling this branch in-cluster and confirming Alertmanager pod recovered; Watchdog remains active

## Validation
- task lint
- task dev:validate (from main checkout)
- task dev:start / task dev:sync on feature branch
- verified Alertmanager Reconciled=True and sent test alert via amtool
