### PR TITLE
📝 Document Taskfile worktree flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ Thumbs.db
 *.swp
 .vscode/
 .idea/
+
+/worktrees/

--- a/.taskfiles/dev/Taskfile.yaml
+++ b/.taskfiles/dev/Taskfile.yaml
@@ -10,6 +10,24 @@ tasks:
       docker run --rm -v {{.ROOT_DIR}}:/github/workspace -w /github/workspace {{.FLUX_LOCAL_IMAGE}} test --enable-helm --all-namespaces --path /github/workspace/kubernetes/flux/cluster -v
     preconditions:
       - which docker
+  worktree:create:
+    desc: Create a feature worktree under ./worktrees and link required local files
+    requires:
+      vars: [NAME, BRANCH]
+    cmds:
+      - mkdir -p {{.ROOT_DIR}}/worktrees
+      - git worktree add {{.ROOT_DIR}}/worktrees/{{.NAME}} -b {{.BRANCH}}
+      - ln -snf {{.ROOT_DIR}}/age.key {{.ROOT_DIR}}/worktrees/{{.NAME}}/age.key
+      - ln -snf {{.ROOT_DIR}}/kubeconfig {{.ROOT_DIR}}/worktrees/{{.NAME}}/kubeconfig
+    preconditions:
+      - which git
+  worktree:remove:
+    desc: Remove a feature worktree from ./worktrees
+    requires:
+      vars: [NAME]
+    cmd: git worktree remove {{.ROOT_DIR}}/worktrees/{{.NAME}}
+    preconditions:
+      - which git
   start:
     desc: Switch Flux to reconcile the current git branch [must not be on main]
     vars:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,13 +59,9 @@ task dev:validate   # renders all Flux HelmReleases and Kustomizations — no cl
 Always work in a git worktree to keep the main checkout on `main` and isolate feature branches:
 
 ```bash
-# Create a worktree for the feature branch (sibling of the main checkout)
-git worktree add ../home-ops-my-change -b feature/my-change
-cd ../home-ops-my-change
-
-# Symlink gitignored files required by dev tasks (Taskfile resolves these from ROOT_DIR)
-ln -s ../home-ops/age.key age.key
-ln -s ../home-ops/kubeconfig kubeconfig
+# Create a worktree for the feature branch under ./worktrees/
+task dev:worktree:create NAME=home-ops-my-change BRANCH=feature/my-change
+cd worktrees/home-ops-my-change
 
 # edit kubernetes/ manifests
 task lint             # auto-fix formatting
@@ -75,8 +71,8 @@ task dev:sync         # push additional commits and reconcile
 task dev:stop         # ALWAYS run this — restores flux-instance and points cluster back at main
 
 # Clean up the worktree when done (must be run from outside the worktree)
-cd ../home-ops
-git worktree remove ../home-ops-my-change
+cd ../..
+git worktree remove worktrees/home-ops-my-change
 ```
 
 > Always run `task dev:stop` when done, even if something went wrong. It restores the
@@ -147,9 +143,8 @@ Replicate CI locally with `task dev:validate` before opening a PR.
 - **`yamlfmt` reformats indentation and multiline strings** — do not manually fight its style;
   always let `task lint` normalize files before committing.
 - **Worktrees share the `.git` directory but not gitignored files** — `age.key` and `kubeconfig`
-  exist only in the main working tree. Symlink them into the worktree before running `dev:` tasks —
-  the Taskfile resolves these from `ROOT_DIR` so env var overrides won't work:
-  `ln -s ../home-ops/age.key age.key && ln -s ../home-ops/kubeconfig kubeconfig`.
+  exist only in the main working tree. Use `task dev:worktree:create` to create the worktree and
+  symlink these files correctly before running `dev:` tasks.
 - **`components/sops` is the only Kustomize component on `main`** — namespace-level
   `kustomization.yaml` files must use `../../components/sops`. Do not copy namespace kustomizations
   from feature branches that used `../../components/common`; that directory does not exist on `main`.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -96,23 +96,21 @@ ______________________________________________________________________
 Defined in `.taskfiles/dev/Taskfile.yaml`. Enables testing changes against the live cluster
 **without pushing to `main`** by temporarily redirecting Flux to watch the current git branch.
 
-| Task                | Description                                                                                                                                              |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `task dev:validate` | Run `flux-local test` locally via Docker — validates all Helm renders and Kustomization builds with no cluster required                                  |
-| `task dev:start`    | Push current branch, suspend the `flux-instance` HelmRelease, patch the `flux-system` GitRepository to watch the current branch, and trigger a reconcile |
-| `task dev:sync`     | Push new commits on the current branch and trigger Flux to reconcile them                                                                                |
-| `task dev:stop`     | Restore the GitRepository to `refs/heads/main`, resume the `flux-instance` HelmRelease, and trigger a reconcile                                          |
+| Task                                                   | Description                                                                                                                                              |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `task dev:validate`                                    | Run `flux-local test` locally via Docker — validates all Helm renders and Kustomization builds with no cluster required                                  |
+| `task dev:worktree:create NAME=<name> BRANCH=<branch>` | Create a feature worktree under `./worktrees/` and symlink `age.key`/`kubeconfig` into it                                                                |
+| `task dev:worktree:remove NAME=<name>`                 | Remove a feature worktree from `./worktrees/`                                                                                                            |
+| `task dev:start`                                       | Push current branch, suspend the `flux-instance` HelmRelease, patch the `flux-system` GitRepository to watch the current branch, and trigger a reconcile |
+| `task dev:sync`                                        | Push new commits on the current branch and trigger Flux to reconcile them                                                                                |
+| `task dev:stop`                                        | Restore the GitRepository to `refs/heads/main`, resume the `flux-instance` HelmRelease, and trigger a reconcile                                          |
 
 **Typical workflow:**
 
 ```bash
-# Create a worktree to isolate the feature branch (sibling of the main checkout)
-git worktree add ../home-ops-my-change -b feature/my-change
-cd ../home-ops-my-change
-
-# Symlink gitignored files required by dev tasks (Taskfile resolves these from ROOT_DIR)
-ln -s ../home-ops/age.key age.key
-ln -s ../home-ops/kubeconfig kubeconfig
+# Create a worktree to isolate the feature branch under ./worktrees/
+task dev:worktree:create NAME=home-ops-my-change BRANCH=feature/my-change
+cd worktrees/home-ops-my-change
 
 # edit kubernetes/ manifests ...
 task dev:start      # redirect Flux at this branch
@@ -122,8 +120,8 @@ task dev:sync       # push + reconcile after each change
 task dev:stop       # restore Flux to main
 
 # Clean up (must be run from outside the worktree)
-cd ../home-ops
-git worktree remove ../home-ops-my-change
+cd ../..
+task dev:worktree:remove NAME=home-ops-my-change
 ```
 
 > `dev:start` suspends the `flux-instance` HelmRelease so the flux-operator does not fight the


### PR DESCRIPTION
## Summary
- add `task dev:worktree:create` and `task dev:worktree:remove` to standardize local worktree management under `./worktrees/`
- update `AGENTS.md` and `docs/TASKS.md` to document Taskfile-only worktree setup/cleanup flow
- add `/worktrees/` to `.gitignore` to prevent accidental commits of local worktrees

## Validation
- task lint (in feature worktree)
- task dev:validate (from main checkout; worktree path is unsupported by flux-local container git root detection)
