### PR TITLE
🤖 Auto-merge Renovate mise minor updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -59,7 +59,7 @@
       matchManagers: ["mise"],
       automerge: true,
       automergeType: "branch",
-      matchUpdateTypes: ["minor"],
+      matchUpdateTypes: ["minor", "patch"],
       minimumReleaseAge: "3 days",
       ignoreTests: true,
     },

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -55,6 +55,15 @@
       ignoreTests: true,
     },
     {
+      description: "Auto-merge Mise minor updates",
+      matchManagers: ["mise"],
+      automerge: true,
+      automergeType: "branch",
+      matchUpdateTypes: ["minor"],
+      minimumReleaseAge: "3 days",
+      ignoreTests: true,
+    },
+    {
       matchUpdateTypes: ["major"],
       semanticCommitType: "💥 ",
       commitMessageExtra: "( {{currentVersion}} → {{newVersion}} )",

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -55,11 +55,11 @@
       ignoreTests: true,
     },
     {
-      description: "Auto-merge Mise minor updates",
+      description: "Auto-merge Mise",
       matchManagers: ["mise"],
       automerge: true,
       automergeType: "branch",
-      matchUpdateTypes: ["minor", "patch"],
+      matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "3 days",
       ignoreTests: true,
     },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,7 +208,7 @@ Renovate runs on a weekend schedule (`.renovaterc.json5`) and opens PRs to updat
 - Tool versions in `.mise.toml`
 
 Annotated inline comments (`# renovate: datasource=...`) drive version tracking for values that
-Renovate cannot auto-detect. GitHub Actions minor/patch updates are auto-merged after 3 days.
+Renovate cannot auto-detect. GitHub Actions minor/patch updates and mise minor updates are auto-merged after 3 days.
 
 ______________________________________________________________________
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,7 +208,7 @@ Renovate runs on a weekend schedule (`.renovaterc.json5`) and opens PRs to updat
 - Tool versions in `.mise.toml`
 
 Annotated inline comments (`# renovate: datasource=...`) drive version tracking for values that
-Renovate cannot auto-detect. GitHub Actions minor/patch updates and mise minor/patch updates are auto-merged after 3 days.
+Renovate cannot auto-detect. GitHub Actions minor/patch/digest updates and mise minor/patch/digest updates are auto-merged after 3 days.
 
 ______________________________________________________________________
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,7 +208,7 @@ Renovate runs on a weekend schedule (`.renovaterc.json5`) and opens PRs to updat
 - Tool versions in `.mise.toml`
 
 Annotated inline comments (`# renovate: datasource=...`) drive version tracking for values that
-Renovate cannot auto-detect. GitHub Actions minor/patch updates and mise minor updates are auto-merged after 3 days.
+Renovate cannot auto-detect. GitHub Actions minor/patch updates and mise minor/patch updates are auto-merged after 3 days.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Summary
- enable Renovate branch automerge for mise manager minor updates
- keep the same 3-day release age guard used for GitHub Actions automerge
- document the behavior in docs/ARCHITECTURE.md

## Validation
- task lint
- flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v (run against the worktree with absolute mount path)
