### PR TITLE
🤖 renovate: annotate renovate-version for tracking

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
           configurationFile: .github/renovate-config.js
+          # renovate: datasource=github-releases depName=renovatebot/renovate
           renovate-version: 43.29.2
         env:
           RENOVATE_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
Adds a Renovate annotation above `renovate-version` in the renovate workflow so the regex custom manager can detect and update it automatically.