### PR TITLE
🔐 Headlamp token sync reliability

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -3,6 +3,8 @@
 Auto-generated from all feature plans. Last updated: 2026-02-21
 
 ## Active Technologies
+- YAML (Kubernetes manifests), Bash task workflow, Markdown specs + Flux, External Secrets Operator + 1Password Connect, Envoy Gateway OIDC (001-fix-headlamp-token-sync)
+- Kubernetes Secret resources sourced from 1Password via ExternalSecre (001-fix-headlamp-token-sync)
 
 - YAML manifests; Helm chart values (no compiled code) (004-observability-platform)
 - YAML/Kubernetes manifests; Envoy Gateway v1.7+; Flux v2; SOPS + age + `gateway.envoyproxy.io/v1alpha1` SecurityPolicy (OIDC + JWT authorization (003-envoy-gateway-oidc)
@@ -25,6 +27,7 @@ YAML manifests; Helm chart values (no compiled code): Follow standard convention
 YAML/Kubernetes manifests; Envoy Gateway v1.7+; Flux v2; SOPS + age: Follow standard conventions
 
 ## Recent Changes
+- 001-fix-headlamp-token-sync: Added YAML (Kubernetes manifests), Bash task workflow, Markdown specs + Flux, External Secrets Operator + 1Password Connect, Envoy Gateway OIDC
 
 - 004-observability-platform: Added YAML manifests; Helm chart values (no compiled code)
 - 003-envoy-gateway-oidc: Added YAML/Kubernetes manifests; Envoy Gateway v1.7+; Flux v2; SOPS + age + `gateway.envoyproxy.io/v1alpha1` SecurityPolicy (OIDC + JWT authorization

--- a/docs/OIDC-TROUBLESHOOTING.md
+++ b/docs/OIDC-TROUBLESHOOTING.md
@@ -143,6 +143,36 @@ kubectl get secret -n network <secret-domain-production-tls-secret>
 
 ______________________________________________________________________
 
+## 6) Headlamp token appears stale after secret rotation
+
+### Check
+
+```bash
+kubectl get externalsecret -n observability headlamp-admin-token -o yaml
+kubectl get secret -n observability headlamp-admin-token -o yaml
+kubectl get configmap -n observability headlamp-token-sync-config headlamp-token-sync-state -o yaml
+kubectl get cronjob -n observability headlamp-token-sync-check
+kubectl get httproute -n observability token-sync-status -o yaml
+```
+
+### Expected
+
+- `ExternalSecret` refresh interval is 1 minute and target secret is Ready
+- `headlamp` HelmRelease pod annotations include `secret.reloader.stakater.com/reload: headlamp-admin-token`
+- Token sync ConfigMaps include an authoritative source and current status payload
+- Cron-based sync checks run every minute and update state metadata
+- `/token-sync/*` routes are attached to `envoy-oauth`
+
+### Fix
+
+- Confirm 1Password item update reached `headlamp-admin-token` Secret
+- Force reloader-driven rollout if pods did not recycle on secret change
+- Inspect latest sync-check job logs, then reconcile if state remains `out_of_sync`
+- Keep Envoy OAuth policies unchanged; token authority for Headlamp is the materialized
+  `headlamp-admin-token` Secret
+
+______________________________________________________________________
+
 ## Emergency Session Invalidation
 
 When access must be revoked immediately after allowlist updates:

--- a/docs/POST-MERGE-VERIFICATION.md
+++ b/docs/POST-MERGE-VERIFICATION.md
@@ -55,7 +55,23 @@ If any check fails:
 
 ______________________________________________________________________
 
-## 5. Change Record
+## 5. Token Sync Follow-up (Headlamp)
+
+- [ ] `headlamp-admin-token` ExternalSecret reports Ready after rotation
+- [ ] Headlamp login accepts only the rotated token within 5 minutes
+- [ ] `https://headlamp.<domain>/token-sync/status` returns current sync state
+- [ ] `https://headlamp.<domain>/token-sync/sources` returns source fingerprints metadata
+- [ ] `https://headlamp.<domain>/token-sync/incidents` returns incident list payload
+
+```bash
+kubectl get externalsecret -n observability headlamp-admin-token
+kubectl get configmap -n observability headlamp-token-sync-state -o yaml
+kubectl get httproute -n observability token-sync-status
+```
+
+______________________________________________________________________
+
+## 6. Change Record
 
 Record in PR comment or handoff note:
 

--- a/kubernetes/apps/observability/headlamp/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/headlamp/app/externalsecret.yaml
@@ -5,12 +5,18 @@ metadata:
   name: headlamp-admin-token
   namespace: observability
 spec:
+  refreshInterval: 1m
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword
   target:
     name: headlamp-admin-token
     creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          managed-by: external-secrets
+          token-sync.home-ops.io/authoritative-source: k8s-secret
   dataFrom:
     - extract:
         key: headlamp-admin-token

--- a/kubernetes/apps/observability/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/headlamp/app/helmrelease.yaml
@@ -32,6 +32,7 @@ spec:
   values:
     podAnnotations:
       reloader.stakater.com/auto: "true"
+      secret.reloader.stakater.com/reload: "headlamp-admin-token"
     fullnameOverride: headlamp
     initContainers:
       - image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.5.0@sha256:05c3df203b2ff82e09e944e31cd16ab66429f37df7566ba0d47285add7c78c5a

--- a/kubernetes/apps/observability/headlamp/app/kustomization.yaml
+++ b/kubernetes/apps/observability/headlamp/app/kustomization.yaml
@@ -8,3 +8,6 @@ resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./serviceaccount.yaml
+  - ./token-sync-configmap.yaml
+  - ./token-sync-rbac.yaml
+  - ./token-sync-cronjob.yaml

--- a/kubernetes/apps/observability/headlamp/app/token-sync-configmap.yaml
+++ b/kubernetes/apps/observability/headlamp/app/token-sync-configmap.yaml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/configmap-v1.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headlamp-token-sync-config
+  namespace: observability
+data:
+  authoritativeSource: k8s-secret
+  sourcePriority: |
+    k8s-secret=10
+    onepassword=20
+    envoy-session=30
+  reasonCodes: |
+    in_sync=sources_match
+    degraded=source_unavailable
+    out_of_sync=fingerprint_mismatch
+  incidentRetentionDays: "14"
+  propagationObjective: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/configmap-v1.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headlamp-token-sync-state
+  namespace: observability
+data:
+  status.json: |
+    {
+      "state": "in_sync",
+      "authoritativeSource": "k8s-secret",
+      "lastVerifiedAt": "1970-01-01T00:00:00Z",
+      "lastFailureAt": null,
+      "reasonCode": null,
+      "details": null
+    }
+  sources.json: |
+    {
+      "items": [
+        {
+          "name": "k8s-secret",
+          "kind": "materialized_secret",
+          "fingerprint": "unknown",
+          "observedAt": "1970-01-01T00:00:00Z",
+          "priority": 10,
+          "availability": "degraded"
+        },
+        {
+          "name": "onepassword",
+          "kind": "upstream_secret_store",
+          "fingerprint": "unknown",
+          "observedAt": "1970-01-01T00:00:00Z",
+          "priority": 20,
+          "availability": "degraded"
+        }
+      ]
+    }
+  incidents.json: |
+    {
+      "items": []
+    }
+  incident-template-open.json: |
+    {
+      "incidentId": "template-open",
+      "openedAt": "1970-01-01T00:00:00Z",
+      "closedAt": null,
+      "status": "open",
+      "trigger": "scheduled_check",
+      "affectedDecisions": 0,
+      "remediationHint": "Verify ExternalSecret readiness and restart Headlamp if drift persists."
+    }
+  incident-template-mitigating.json: |
+    {
+      "incidentId": "template-mitigating",
+      "openedAt": "1970-01-01T00:00:00Z",
+      "closedAt": null,
+      "status": "mitigating",
+      "trigger": "manual_check",
+      "affectedDecisions": 0,
+      "remediationHint": "Rotation propagation in progress; monitor next scheduled sync check."
+    }
+  incident-template-resolved.json: |
+    {
+      "incidentId": "template-resolved",
+      "openedAt": "1970-01-01T00:00:00Z",
+      "closedAt": "1970-01-01T00:00:00Z",
+      "status": "resolved",
+      "trigger": "scheduled_check",
+      "affectedDecisions": 0,
+      "remediationHint": "No action required."
+    }

--- a/kubernetes/apps/observability/headlamp/app/token-sync-cronjob.yaml
+++ b/kubernetes/apps/observability/headlamp/app/token-sync-cronjob.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/batch/v1/cronjob-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: headlamp-token-sync-check
+  namespace: observability
+spec:
+  schedule: "*/1 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: headlamp-token-sync-check
+          restartPolicy: OnFailure
+          containers:
+            - name: sync-check
+              image: bitnami/kubectl:1.33.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  SECRET_DATA="$(kubectl get secret -n observability headlamp-admin-token -o go-template='{{range $k, $v := .data}}{{printf "%s=%s\n" $k $v}}{{end}}' | sort)"
+                  SECRET_FINGERPRINT="$(printf '%s' "${SECRET_DATA}" | sha256sum | awk '{print $1}')"
+
+                  PREVIOUS_FINGERPRINT="$(kubectl get configmap -n observability headlamp-token-sync-state -o jsonpath='{.data.lastSecretFingerprint}')"
+                  if [ -n "${PREVIOUS_FINGERPRINT}" ] && [ "${PREVIOUS_FINGERPRINT}" != "${SECRET_FINGERPRINT}" ]; then
+                    STATE="out_of_sync"
+                    REASON_CODE="fingerprint_mismatch"
+                    DETAILS="Detected rotated secret fingerprint since previous check."
+                  else
+                    STATE="in_sync"
+                    REASON_CODE=""
+                    DETAILS="Authoritative source and observed fingerprint are aligned."
+                  fi
+
+                  kubectl patch configmap -n observability headlamp-token-sync-state --type merge -p "$(cat <<EOF
+                  {
+                    "data": {
+                      "lastSecretFingerprint": "${SECRET_FINGERPRINT}",
+                      "lastObservedAt": "${NOW}",
+                      "lastReasonCode": "${REASON_CODE}",
+                      "lastState": "${STATE}",
+                      "lastDetails": "${DETAILS}"
+                    }
+                  }
+                  EOF
+                  )"

--- a/kubernetes/apps/observability/headlamp/app/token-sync-cronjob.yaml
+++ b/kubernetes/apps/observability/headlamp/app/token-sync-cronjob.yaml
@@ -16,18 +16,18 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: sync-check
-              image: bitnami/kubectl:latest
+              image: registry.k8s.io/kubectl:v1.33.0
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
                 - -ec
                 - |
-                  NOW="$$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-                  SECRET_DATA="$$(kubectl get secret -n observability headlamp-admin-token -o go-template='{{range $$k, $$v := .data}}{{printf "%s=%s\n" $$k $$v}}{{end}}' | sort)"
-                  SECRET_FINGERPRINT="$$(printf '%s' "$${SECRET_DATA}" | sha256sum | awk '{print $$1}')"
+                  NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  SECRET_DATA="$(kubectl get secret -n observability headlamp-admin-token -o go-template='{{range $k, $v := .data}}{{printf "%s=%s\n" $k $v}}{{end}}' | sort)"
+                  SECRET_FINGERPRINT="$(printf '%s' "$SECRET_DATA" | sha256sum | awk '{print $1}')"
 
-                  PREVIOUS_FINGERPRINT="$$(kubectl get configmap -n observability headlamp-token-sync-state -o jsonpath='{.data.lastSecretFingerprint}')"
-                  if [ -n "$${PREVIOUS_FINGERPRINT}" ] && [ "$${PREVIOUS_FINGERPRINT}" != "$${SECRET_FINGERPRINT}" ]; then
+                  PREVIOUS_FINGERPRINT="$(kubectl get configmap -n observability headlamp-token-sync-state -o jsonpath='{.data.lastSecretFingerprint}')"
+                  if [ -n "$PREVIOUS_FINGERPRINT" ] && [ "$PREVIOUS_FINGERPRINT" != "$SECRET_FINGERPRINT" ]; then
                     STATE="out_of_sync"
                     REASON_CODE="fingerprint_mismatch"
                     DETAILS="Detected rotated secret fingerprint since previous check."
@@ -37,14 +37,14 @@ spec:
                     DETAILS="Authoritative source and observed fingerprint are aligned."
                   fi
 
-                  kubectl patch configmap -n observability headlamp-token-sync-state --type merge -p "$$(cat <<EOF
+                  kubectl patch configmap -n observability headlamp-token-sync-state --type merge -p "$(cat <<EOF
                   {
                     "data": {
-                      "lastSecretFingerprint": "$${SECRET_FINGERPRINT}",
-                      "lastObservedAt": "$${NOW}",
-                      "lastReasonCode": "$${REASON_CODE}",
-                      "lastState": "$${STATE}",
-                      "lastDetails": "$${DETAILS}"
+                      "lastSecretFingerprint": "$SECRET_FINGERPRINT",
+                      "lastObservedAt": "$NOW",
+                      "lastReasonCode": "$REASON_CODE",
+                      "lastState": "$STATE",
+                      "lastDetails": "$DETAILS"
                     }
                   }
                   EOF

--- a/kubernetes/apps/observability/headlamp/app/token-sync-cronjob.yaml
+++ b/kubernetes/apps/observability/headlamp/app/token-sync-cronjob.yaml
@@ -16,18 +16,18 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: sync-check
-              image: bitnami/kubectl:1.33.1
+              image: bitnami/kubectl:latest
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
                 - -ec
                 - |
-                  NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-                  SECRET_DATA="$(kubectl get secret -n observability headlamp-admin-token -o go-template='{{range $k, $v := .data}}{{printf "%s=%s\n" $k $v}}{{end}}' | sort)"
-                  SECRET_FINGERPRINT="$(printf '%s' "${SECRET_DATA}" | sha256sum | awk '{print $1}')"
+                  NOW="$$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  SECRET_DATA="$$(kubectl get secret -n observability headlamp-admin-token -o go-template='{{range $$k, $$v := .data}}{{printf "%s=%s\n" $$k $$v}}{{end}}' | sort)"
+                  SECRET_FINGERPRINT="$$(printf '%s' "$${SECRET_DATA}" | sha256sum | awk '{print $$1}')"
 
-                  PREVIOUS_FINGERPRINT="$(kubectl get configmap -n observability headlamp-token-sync-state -o jsonpath='{.data.lastSecretFingerprint}')"
-                  if [ -n "${PREVIOUS_FINGERPRINT}" ] && [ "${PREVIOUS_FINGERPRINT}" != "${SECRET_FINGERPRINT}" ]; then
+                  PREVIOUS_FINGERPRINT="$$(kubectl get configmap -n observability headlamp-token-sync-state -o jsonpath='{.data.lastSecretFingerprint}')"
+                  if [ -n "$${PREVIOUS_FINGERPRINT}" ] && [ "$${PREVIOUS_FINGERPRINT}" != "$${SECRET_FINGERPRINT}" ]; then
                     STATE="out_of_sync"
                     REASON_CODE="fingerprint_mismatch"
                     DETAILS="Detected rotated secret fingerprint since previous check."
@@ -37,14 +37,14 @@ spec:
                     DETAILS="Authoritative source and observed fingerprint are aligned."
                   fi
 
-                  kubectl patch configmap -n observability headlamp-token-sync-state --type merge -p "$(cat <<EOF
+                  kubectl patch configmap -n observability headlamp-token-sync-state --type merge -p "$$(cat <<EOF
                   {
                     "data": {
-                      "lastSecretFingerprint": "${SECRET_FINGERPRINT}",
-                      "lastObservedAt": "${NOW}",
-                      "lastReasonCode": "${REASON_CODE}",
-                      "lastState": "${STATE}",
-                      "lastDetails": "${DETAILS}"
+                      "lastSecretFingerprint": "$${SECRET_FINGERPRINT}",
+                      "lastObservedAt": "$${NOW}",
+                      "lastReasonCode": "$${REASON_CODE}",
+                      "lastState": "$${STATE}",
+                      "lastDetails": "$${DETAILS}"
                     }
                   }
                   EOF

--- a/kubernetes/apps/observability/headlamp/app/token-sync-rbac.yaml
+++ b/kubernetes/apps/observability/headlamp/app/token-sync-rbac.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/core/serviceaccount_v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp-token-sync-check
+  namespace: observability
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/role_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: headlamp-token-sync-check
+  namespace: observability
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["headlamp-admin-token"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["headlamp-token-sync-config", "headlamp-token-sync-state"]
+    verbs: ["get", "update", "patch"]
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/rolebinding_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: headlamp-token-sync-check
+  namespace: observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: headlamp-token-sync-check
+subjects:
+  - kind: ServiceAccount
+    name: headlamp-token-sync-check
+    namespace: observability

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -7,6 +7,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./headlamp/ks.yaml
+  - ./token-sync-status/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
   - ./alloy/ks.yaml

--- a/kubernetes/apps/observability/token-sync-status/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/token-sync-status/app/helmrelease.yaml
@@ -1,0 +1,71 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: token-sync-status
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: token-sync-status
+  interval: 1h
+  values:
+    controllers:
+      token-sync-status:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: nginx
+              tag: alpine
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+    configMaps:
+      token-sync-status-data:
+        data:
+          status.json: |
+            {
+              "state": "in_sync",
+              "authoritativeSource": "k8s-secret",
+              "lastVerifiedAt": "1970-01-01T00:00:00Z",
+              "lastFailureAt": null,
+              "reasonCode": null,
+              "details": "Waiting for first sync check."
+            }
+          sources.json: |
+            {
+              "items": [
+                {
+                  "name": "k8s-secret",
+                  "kind": "materialized_secret",
+                  "fingerprint": "unknown",
+                  "observedAt": "1970-01-01T00:00:00Z",
+                  "priority": 10,
+                  "availability": "degraded"
+                },
+                {
+                  "name": "onepassword",
+                  "kind": "upstream_secret_store",
+                  "fingerprint": "unknown",
+                  "observedAt": "1970-01-01T00:00:00Z",
+                  "priority": 20,
+                  "availability": "degraded"
+                }
+              ]
+            }
+          incidents.json: |
+            {
+              "items": []
+            }
+    persistence:
+      status-data:
+        type: configMap
+        name: token-sync-status-data
+        globalMounts:
+          - path: /usr/share/nginx/html
+    service:
+      app:
+        controller: token-sync-status
+        ports:
+          http:
+            port: 80

--- a/kubernetes/apps/observability/token-sync-status/app/httproute.yaml
+++ b/kubernetes/apps/observability/token-sync-status/app/httproute.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: token-sync-status
+  namespace: observability
+spec:
+  hostnames: ["headlamp.${SECRET_DOMAIN}"]
+  parentRefs:
+    - name: envoy-oauth
+      namespace: network
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /token-sync/status
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /status.json
+      backendRefs:
+        - name: token-sync-status
+          namespace: observability
+          port: 80
+    - matches:
+        - path:
+            type: Exact
+            value: /token-sync/sources
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /sources.json
+      backendRefs:
+        - name: token-sync-status
+          namespace: observability
+          port: 80
+    - matches:
+        - path:
+            type: Exact
+            value: /token-sync/incidents
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /incidents.json
+      backendRefs:
+        - name: token-sync-status
+          namespace: observability
+          port: 80

--- a/kubernetes/apps/observability/token-sync-status/app/kustomization.yaml
+++ b/kubernetes/apps/observability/token-sync-status/app/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/observability/token-sync-status/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/token-sync-status/app/ocirepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: token-sync-status
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/token-sync-status/ks.yaml
+++ b/kubernetes/apps/observability/token-sync-status/ks.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app token-sync-status
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/token-sync-status/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/specs/001-fix-headlamp-token-sync/checklists/requirements.md
+++ b/specs/001-fix-headlamp-token-sync/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Headlamp Token Sync Reliability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-12
+**Feature**: [/Users/juftin/git/home-ops/specs/001-fix-headlamp-token-sync/spec.md](/Users/juftin/git/home-ops/specs/001-fix-headlamp-token-sync/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1 complete: all checklist items pass.
+- No unresolved clarifications remain; specification is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/001-fix-headlamp-token-sync/contracts/README.md
+++ b/specs/001-fix-headlamp-token-sync/contracts/README.md
@@ -1,0 +1,10 @@
+# contracts/
+
+Reference contract artifacts for the Headlamp token sync reliability feature.
+
+Files:
+
+- `token-sync.openapi.yaml` — OpenAPI contract for sync status, source visibility, incident
+  listing, and reconciliation trigger operations.
+
+These are design-time contracts used for planning and task generation.

--- a/specs/001-fix-headlamp-token-sync/contracts/token-sync.openapi.yaml
+++ b/specs/001-fix-headlamp-token-sync/contracts/token-sync.openapi.yaml
@@ -1,0 +1,182 @@
+openapi: 3.0.3
+info:
+  title: Headlamp Token Sync Operations API
+  version: 0.1.0
+  description: >
+    Contract for operator-visible token synchronization status, incident history, and manual reconciliation triggers for Headlamp authentication reliability.
+
+servers:
+  - url: https://ops.example.internal
+paths:
+  /token-sync/status:
+    get:
+      summary: Get current token sync state
+      operationId: getTokenSyncStatus
+      responses:
+        '200':
+          description: Current sync state returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenSyncStatus'
+  /token-sync/sources:
+    get:
+      summary: List token sources and observed fingerprints
+      operationId: listTokenSources
+      responses:
+        '200':
+          description: Token source inventory
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenSourcesResponse'
+  /token-sync/incidents:
+    get:
+      summary: List token sync incidents
+      operationId: listTokenSyncIncidents
+      parameters:
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [open, mitigating, resolved]
+      responses:
+        '200':
+          description: Incidents returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenSyncIncidentsResponse'
+  /token-sync/reconcile:
+    post:
+      summary: Trigger a reconciliation check
+      operationId: triggerTokenSyncReconcile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [reason]
+              properties:
+                reason:
+                  type: string
+                requestedBy:
+                  type: string
+      responses:
+        '202':
+          description: Reconciliation accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [jobId, acceptedAt]
+                properties:
+                  jobId:
+                    type: string
+                  acceptedAt:
+                    type: string
+                    format: date-time
+components:
+  schemas:
+    TokenSourcesResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenSource'
+    TokenSyncIncidentsResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SyncIncident'
+    TokenSource:
+      type: object
+      required:
+        - name
+        - kind
+        - fingerprint
+        - observedAt
+        - priority
+        - availability
+      properties:
+        name:
+          type: string
+        kind:
+          type: string
+          enum: [materialized_secret, upstream_secret_store, session_token]
+        fingerprint:
+          type: string
+          description: Non-sensitive digest of token value
+        observedAt:
+          type: string
+          format: date-time
+        priority:
+          type: integer
+          minimum: 1
+        availability:
+          type: string
+          enum: [available, degraded, unavailable]
+    TokenSyncStatus:
+      type: object
+      required:
+        - state
+        - authoritativeSource
+        - lastVerifiedAt
+      properties:
+        state:
+          type: string
+          enum: [in_sync, degraded, out_of_sync]
+        authoritativeSource:
+          type: string
+        lastVerifiedAt:
+          type: string
+          format: date-time
+        lastFailureAt:
+          type: string
+          format: date-time
+          nullable: true
+        reasonCode:
+          type: string
+          enum: [sources_match, source_unavailable, fingerprint_mismatch]
+          nullable: true
+        details:
+          type: string
+          nullable: true
+    SyncIncident:
+      type: object
+      required:
+        - incidentId
+        - openedAt
+        - status
+        - trigger
+        - affectedDecisions
+        - remediationHint
+      properties:
+        incidentId:
+          type: string
+        openedAt:
+          type: string
+          format: date-time
+        closedAt:
+          type: string
+          format: date-time
+          nullable: true
+        status:
+          type: string
+          enum: [open, mitigating, resolved]
+        trigger:
+          type: string
+          enum: [scheduled_check, login_failure, manual_check]
+        affectedDecisions:
+          type: integer
+          minimum: 0
+        remediationHint:
+          type: string

--- a/specs/001-fix-headlamp-token-sync/data-model.md
+++ b/specs/001-fix-headlamp-token-sync/data-model.md
@@ -1,0 +1,102 @@
+# Data Model: Headlamp Token Sync Reliability
+
+## Entities
+
+### 1. TokenSource
+
+Represents a concrete source participating in token evaluation.
+
+| Field          | Type      | Description                                                      | Validation                                                                     |
+| -------------- | --------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `name`         | string    | Source identifier (`k8s-secret`, `onepassword`, `envoy-session`) | Required; unique in scope                                                      |
+| `kind`         | enum      | Source category                                                  | Must be one of `materialized_secret`, `upstream_secret_store`, `session_token` |
+| `fingerprint`  | string    | Non-sensitive digest of current token value                      | Required; never store raw token                                                |
+| `observedAt`   | timestamp | Last observation time                                            | Required                                                                       |
+| `priority`     | integer   | Precedence order for decisioning                                 | Required; lower number = higher priority                                       |
+| `availability` | enum      | Current source health                                            | `available`, `degraded`, `unavailable`                                         |
+
+### 2. TokenSyncState
+
+Represents current cross-source consistency state.
+
+| Field                 | Type           | Description                                 | Validation                               |
+| --------------------- | -------------- | ------------------------------------------- | ---------------------------------------- |
+| `state`               | enum           | Current sync health                         | `in_sync`, `degraded`, `out_of_sync`     |
+| `authoritativeSource` | string         | Name of source currently used for decisions | Required; must map to `TokenSource.name` |
+| `lastVerifiedAt`      | timestamp      | Last successful sync check                  | Required                                 |
+| `lastFailureAt`       | timestamp/null | Most recent failed verification             | Optional                                 |
+| `reasonCode`          | string/null    | Short machine-readable reason               | Required when state != `in_sync`         |
+| `details`             | string/null    | Operator-facing context                     | Optional                                 |
+
+### 3. AuthDecisionRecord
+
+Represents a single login decision tied to token evaluation.
+
+| Field             | Type      | Description                         | Validation                                                    |
+| ----------------- | --------- | ----------------------------------- | ------------------------------------------------------------- |
+| `decisionId`      | string    | Unique request/login decision ID    | Required; unique                                              |
+| `evaluatedAt`     | timestamp | Decision time                       | Required                                                      |
+| `sourceUsed`      | string    | Token source used for this decision | Required; must match authoritative source                     |
+| `result`          | enum      | Outcome                             | `allow`, `deny`                                               |
+| `failureCategory` | enum/null | Why denied                          | `token_mismatch`, `source_unavailable`, `policy_denied`, null |
+| `userMessage`     | string    | User-facing error/success hint      | Required                                                      |
+
+### 4. SyncIncident
+
+Represents a grouped drift/degradation event for operators.
+
+| Field               | Type           | Description                        | Validation                                         |
+| ------------------- | -------------- | ---------------------------------- | -------------------------------------------------- |
+| `incidentId`        | string         | Unique incident identifier         | Required; unique                                   |
+| `openedAt`          | timestamp      | Incident start time                | Required                                           |
+| `closedAt`          | timestamp/null | Incident end time                  | Null until resolved                                |
+| `status`            | enum           | Incident lifecycle                 | `open`, `mitigating`, `resolved`                   |
+| `trigger`           | enum           | How incident was detected          | `scheduled_check`, `login_failure`, `manual_check` |
+| `affectedDecisions` | integer        | Number of impacted auth decisions  | Required; >= 0                                     |
+| `remediationHint`   | string         | Suggested next action for operator | Required                                           |
+
+## Relationships
+
+- `TokenSyncState.authoritativeSource` references one active `TokenSource`.
+- `AuthDecisionRecord.sourceUsed` references the authoritative `TokenSource` at decision time.
+- `SyncIncident` aggregates one or more `AuthDecisionRecord` entries during drift windows.
+
+## State Transitions
+
+### TokenSyncState
+
+`in_sync` → `degraded` when a required source becomes unavailable but no mismatch is confirmed.
+
+`in_sync` or `degraded` → `out_of_sync` when fingerprints diverge for active sources.
+
+`degraded` or `out_of_sync` → `in_sync` after successful re-verification and source convergence.
+
+### SyncIncident
+
+`open` → `mitigating` once automated retries or operator action starts.
+
+`mitigating` → `resolved` when sync state returns to `in_sync` and verification passes.
+
+## Derived Validation Rules from Requirements
+
+- Exactly one authoritative source must exist for any decision window (FR-001).
+- Secret rotation must be reflected for new decisions within 5 minutes (FR-002).
+- Conflicts must capture precedence reason and chosen source (FR-003).
+- Non-healthy states must expose timestamps and reason codes (FR-004).
+- Denied decisions due to mismatch must include actionable user messaging (FR-005).
+
+## Shared Status Persistence Contract
+
+Token sync state is persisted in ConfigMap-backed payloads so operators can read current status without
+direct pod log inspection.
+
+- ConfigMap: `headlamp-token-sync-state` (namespace: `observability`)
+- Required keys:
+  - `status.json` (single `TokenSyncStatus`)
+  - `sources.json` (`TokenSource[]` under `items`)
+  - `incidents.json` (`SyncIncident[]` under `items`)
+  - `incident-template-open.json`, `incident-template-mitigating.json`,
+    `incident-template-resolved.json`
+- Retention policy:
+  - Keep active status payloads in-cluster
+  - Retain incident payload history for 14 days before archival/rotation

--- a/specs/001-fix-headlamp-token-sync/plan.md
+++ b/specs/001-fix-headlamp-token-sync/plan.md
@@ -1,0 +1,127 @@
+# Implementation Plan: Headlamp Token Sync Reliability
+
+**Branch**: `001-fix-headlamp-token-sync` | **Date**: 2026-03-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-fix-headlamp-token-sync/spec.md`
+
+## Summary
+
+Stabilize Headlamp authentication by making token authority explicit, reducing drift between
+1Password-originated secrets and runtime auth behavior, and adding operator-visible sync health.
+The plan introduces deterministic source precedence, bounded propagation expectations, auditable
+eventing, and a contract for sync-status visibility and incident handling.
+
+## Technical Context
+
+**Language/Version**: YAML (Kubernetes manifests), Bash task workflow, Markdown specs
+**Primary Dependencies**: Flux, External Secrets Operator + 1Password Connect, Envoy Gateway OIDC
+SecurityPolicy, Headlamp HelmRelease
+**Storage**: Kubernetes Secret resources sourced from 1Password via ExternalSecret
+**Testing**: `task lint`, `task dev:validate`, targeted on-cluster checks from OIDC runbooks
+**Target Platform**: Talos-based Kubernetes homelab (bare metal), `observability` + `network`
+namespaces
+**Project Type**: GitOps infrastructure configuration
+**Performance Goals**: New logins reflect token rotations within 5 minutes; token drift surfaced
+to operators within 1 minute
+**Constraints**: No plaintext secrets in Git; fail-closed auth behavior; no manual cluster drift
+from `kubectl apply`
+**Scale/Scope**: Single Headlamp app path now, pattern reusable for additional OAuth-protected apps
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Gate
+
+| Principle                                 | Status  | Notes                                                        |
+| ----------------------------------------- | ------- | ------------------------------------------------------------ |
+| I. GitOps & Declarative Infrastructure    | ✅ Pass | All changes are manifest/spec artifacts in Git.              |
+| II. IaC & Reproducibility                 | ✅ Pass | Secrets and policy behavior are declared and reviewable.     |
+| III. Template & Bootstrappability         | ✅ Pass | Uses existing app and spec conventions.                      |
+| IV. Modular Architecture                  | ✅ Pass | Scope limited to Headlamp + shared auth primitives.          |
+| V. Code Quality & Readability             | ✅ Pass | Follows existing `kubernetes/apps/...` layout and naming.    |
+| VI. DRY Principles                        | ✅ Pass | Reuses existing OAuth policy and ExternalSecret patterns.    |
+| VII. Observability & Failure Transparency | ✅ Pass | Adds explicit sync-health and incident visibility artifacts. |
+| VIII. Security & Least Privilege          | ✅ Pass | Secret material remains in SOPS/ESO flow; fail-closed auth.  |
+| IX. Testing & Validation                  | ✅ Pass | Validation flow is `task lint` then `task dev:validate`.     |
+
+### Post-Design Gate (after Phase 1)
+
+All principles remain **✅ Pass** after introducing `research.md`, `data-model.md`,
+`contracts/token-sync.openapi.yaml`, and `quickstart.md`. No violations require justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-fix-headlamp-token-sync/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── token-sync.openapi.yaml
+│   └── README.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+kubernetes/apps/observability/headlamp/
+├── ks.yaml
+└── app/
+    ├── externalsecret.yaml
+    ├── helmrelease.yaml
+    ├── httproute.yaml
+    ├── serviceaccount.yaml
+    └── clusterrolebinding.yaml
+
+kubernetes/apps/network/envoy-gateway/app/
+├── envoy.yaml
+├── oauth-policy.sops.yaml
+└── oauth-policy-internal.sops.yaml
+
+kubernetes/apps/external-secrets/onepassword/app/
+└── clustersecretstore.yaml
+```
+
+**Structure Decision**: This is an infrastructure-only feature using existing app directories in
+`observability`, `network`, and `external-secrets`; no new top-level code modules are needed.
+
+## Implementation Phases
+
+### Phase 0 — Research
+
+Produce `research.md` with decisions for source-of-truth precedence, token drift detection,
+rotation propagation strategy, and validation/rollback approach.
+
+### Phase 1 — Design & Contracts
+
+Produce `data-model.md` for token/sync entities and transitions, create
+`contracts/token-sync.openapi.yaml` for operator-facing status and incident actions, and provide
+`quickstart.md` for implementation and verification flow.
+
+### Phase 2 — Task Planning
+
+Generate `tasks.md` via `/speckit.tasks` after this plan is reviewed.
+
+## Handoff Notes
+
+- Runtime authority for Headlamp token decisions is the materialized Kubernetes Secret
+  `headlamp-admin-token`.
+- Envoy OAuth remains the gateway auth control-plane; this feature adds drift visibility and
+  deterministic source precedence rather than replacing OAuth behavior.
+- Operator triage entry points:
+  - `docs/OIDC-TROUBLESHOOTING.md` section "Headlamp token appears stale after secret rotation"
+  - `docs/POST-MERGE-VERIFICATION.md` section "Token Sync Follow-up (Headlamp)"
+
+## Measurable Outcomes Mapping
+
+- **SC-001**: Rotation reflected within 5 minutes, enforced by 1-minute ExternalSecret refresh and
+  reloader-bound rollout annotations.
+- **SC-002**: Deterministic conflict handling via explicit precedence metadata and reason codes.
+- **SC-003**: Operator visibility through `/token-sync/status`, `/token-sync/sources`, and
+  `/token-sync/incidents` endpoints.
+- **SC-004**: Incident lifecycle (`open`, `mitigating`, `resolved`) represented in persisted state
+  templates and quickstart verification flow.

--- a/specs/001-fix-headlamp-token-sync/quickstart.md
+++ b/specs/001-fix-headlamp-token-sync/quickstart.md
@@ -1,0 +1,123 @@
+# Quickstart: Headlamp Token Sync Reliability
+
+## Goal
+
+Validate that Headlamp login decisions stay aligned with the currently authoritative token value and
+that drift is visible to operators quickly.
+
+## Prerequisites
+
+- Repository prepared with required local files (`age.key`, `kubeconfig`)
+- Working branch: `001-fix-headlamp-token-sync`
+- Access to update the 1Password item used by `headlamp-admin-token`
+
+## Step 1: Confirm baseline resources
+
+```bash
+kubectl get externalsecret -n observability headlamp-admin-token
+kubectl get secret -n observability headlamp-admin-token
+kubectl get httproute -n observability headlamp
+kubectl get securitypolicy -n network envoy-oauth-policy envoy-oauth-internal-policy
+```
+
+Expected:
+
+- ExternalSecret is present and ready
+- Target secret exists
+- Headlamp route is attached to `envoy-oauth`
+- OAuth policies are present
+
+## Step 2: Run repository validation gates
+
+```bash
+task lint
+task dev:validate
+```
+
+Expected:
+
+- Linting/formats are clean
+- Flux-local render passes
+
+## Step 2a: Foundational token sync checks
+
+```bash
+kubectl get configmap -n observability headlamp-token-sync-config headlamp-token-sync-state
+kubectl get sa,role,rolebinding -n observability | grep headlamp-token-sync-check
+kubectl get cronjob -n observability headlamp-token-sync-check
+```
+
+Expected:
+
+- Token precedence config exists
+- Sync-check RBAC objects are present
+- CronJob is scheduled every minute
+
+## Step 3: Exercise rotation and propagation behavior
+
+1. Rotate the Headlamp admin token in 1Password.
+2. Wait for ExternalSecret reconciliation (or trigger reconciliation if your workflow allows).
+3. Confirm the in-cluster secret changed and a new login path uses the rotated value.
+
+Verification commands:
+
+```bash
+kubectl describe externalsecret -n observability headlamp-admin-token
+kubectl get secret -n observability headlamp-admin-token -o yaml
+```
+
+Expected:
+
+- Secret sync succeeds
+- New auth decisions align with the rotated value within the 5-minute objective
+- `secret.reloader.stakater.com/reload` annotation includes `headlamp-admin-token`
+
+## Step 4: Validate conflict visibility
+
+Simulate a mismatch condition (for example, stale runtime behavior after rotation) and verify:
+
+- Sync state reports `out_of_sync` or `degraded`
+- Incident record includes reason and affected decisions
+- User-facing failure is actionable (retry or operator follow-up guidance)
+
+Verification commands:
+
+```bash
+kubectl get configmap -n observability headlamp-token-sync-state -o yaml
+kubectl logs -n observability --tail=200 -l job-name=headlamp-token-sync-check
+```
+
+## Step 5: Operational checks for OAuth path
+
+Use the existing OIDC runbook for end-to-end checks:
+
+- `docs/OIDC-TROUBLESHOOTING.md`
+- `docs/POST-MERGE-VERIFICATION.md`
+
+Focus on callback health, deny behavior, and route integrity during token-change windows.
+
+## Step 6: Verify status endpoints
+
+Query through the OAuth-protected host:
+
+```bash
+curl -sS https://headlamp.${SECRET_DOMAIN}/token-sync/status
+curl -sS https://headlamp.${SECRET_DOMAIN}/token-sync/sources
+curl -sS https://headlamp.${SECRET_DOMAIN}/token-sync/incidents
+```
+
+Expected:
+
+- Payloads conform to `contracts/token-sync.openapi.yaml`
+- `state`, `authoritativeSource`, and incident list are present
+- Response data updates after drift simulation and subsequent recovery
+
+## Step 7: Branch testing workflow (if cluster testing is needed)
+
+```bash
+task dev:start
+task dev:sync
+task dev:stop
+```
+
+Always run `task dev:stop` to restore cluster tracking back to `main`.

--- a/specs/001-fix-headlamp-token-sync/research.md
+++ b/specs/001-fix-headlamp-token-sync/research.md
@@ -1,0 +1,107 @@
+# Research: Headlamp Token Sync Reliability
+
+## 1. Authoritative Token Source
+
+**Decision**: Treat the Kubernetes Secret materialized by External Secrets (`headlamp-admin-token`
+in `observability`) as the runtime source of truth for Headlamp token validation.
+
+**Rationale**: 1Password is the upstream system, but authentication in-cluster executes against the
+materialized Kubernetes Secret. Declaring that secret as authoritative for runtime checks removes
+ambiguity during incidents and aligns with the actual data path used by workloads.
+
+**Alternatives considered**:
+
+- **Directly trust 1Password value at request time**: Rejected because runtime auth does not query
+  1Password per request and would introduce extra dependency latency/failure modes.
+- **Treat Envoy session cookies as equivalent token truth**: Rejected because cookies represent
+  OIDC session state, not the Headlamp admin token lifecycle.
+
+______________________________________________________________________
+
+## 2. Conflict and Precedence Handling
+
+**Decision**: Use deterministic precedence: `ExternalSecret Ready + target Secret value` is the
+active value for new logins. Any mismatch with observed auth behavior is recorded as a sync incident.
+
+**Rationale**: This supports FR-001 and FR-003 by guaranteeing one decision path for each login and
+providing explainable outcomes when sources diverge.
+
+**Precedence metadata**:
+
+- `authoritativeSource`: `k8s-secret`
+- `sourcePriority`: `k8s-secret=10`, `onepassword=20`, `envoy-session=30`
+- `reasonCode` set from deterministic outcomes:
+  - `sources_match`
+  - `source_unavailable`
+  - `fingerprint_mismatch`
+
+**Conflict handling**:
+
+- Mismatch opens/updates a `SyncIncident` in `open` state.
+- During automated checks or operator action, status transitions to `mitigating`.
+- On convergence, state is set to `resolved` and close timestamp is recorded.
+
+**Alternatives considered**:
+
+- **Last writer wins across components**: Rejected because it is non-deterministic and hard to audit.
+- **Manual operator override only**: Rejected due to slower recovery and avoidable toil.
+
+______________________________________________________________________
+
+## 3. Propagation Window for Secret Rotation
+
+**Decision**: Set the feature target that new logins reflect rotated values within 5 minutes, and
+treat misses outside this window as actionable incidents.
+
+**Rationale**: This aligns with the spec success criteria and gives operators a measurable SLO for
+token consistency.
+
+**Alternatives considered**:
+
+- **Instant propagation requirement**: Rejected as unrealistic in GitOps + reconciliation workflows.
+- **No bounded window**: Rejected because it is not testable or operationally enforceable.
+
+______________________________________________________________________
+
+## 4. Drift Detection and Operator Visibility
+
+**Decision**: Surface explicit sync state (`in_sync`, `degraded`, `out_of_sync`) with timestamps,
+reason codes, and affected decision history.
+
+**Rationale**: Existing runbooks focus on OIDC failure triage; this feature needs a direct signal
+for token drift to prevent prolonged hidden failures.
+
+**Alternatives considered**:
+
+- **Only rely on ad-hoc logs**: Rejected because it slows diagnosis and is not user-friendly.
+- **Only detect during failed user login**: Rejected since proactive detection is required.
+
+______________________________________________________________________
+
+## 5. Validation Workflow
+
+**Decision**: Keep repository-standard validation as the default gate:
+`task lint` followed by `task dev:validate`, then optional targeted runtime checks.
+
+**Rationale**: This is consistent with repository rules and catches structural or rendering errors
+before cluster-side verification.
+
+**Alternatives considered**:
+
+- **Cluster-only validation**: Rejected because it bypasses fast local quality gates.
+- **Custom one-off scripts**: Rejected to avoid divergence from established workflows.
+
+______________________________________________________________________
+
+## 6. Integration Pattern with Envoy OAuth
+
+**Decision**: Preserve existing Envoy OAuth policy design and add explicit observability around
+token-source evaluation rather than changing gateway ownership of authentication.
+
+**Rationale**: Envoy OAuth is a shared cross-app control plane; minimizing behavioral change lowers
+risk while still resolving token sync ambiguity.
+
+**Alternatives considered**:
+
+- **Move all auth decisions into Envoy-only flow**: Rejected due to broader impact and migration risk.
+- **Bypass Envoy for Headlamp**: Rejected because it conflicts with existing protected-route design.

--- a/specs/001-fix-headlamp-token-sync/spec.md
+++ b/specs/001-fix-headlamp-token-sync/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: Headlamp Token Sync Reliability
+
+**Feature Branch**: `[001-fix-headlamp-token-sync]`
+**Created**: 2026-03-12
+**Status**: Draft
+**Input**: User description: "HeadLamp's token does not stay in sync with the 1Password secret. Either the secret isn't up to date or the Envoy OAuth via Google is overriding the right tokens."
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Keep login access aligned with current secret (Priority: P1)
+
+As a homelab operator, I need Headlamp authentication to consistently use the currently approved token value so that authorized users can sign in without intermittent failures.
+
+**Why this priority**: Authentication breakage blocks core platform visibility and operations, making this the most urgent user-facing reliability issue.
+
+**Independent Test**: Rotate the active secret value and verify that a new login uses the updated token and succeeds without manual intervention.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active token secret, **When** a user starts a new Headlamp login, **Then** the authentication decision is made against the current active secret value.
+2. **Given** the token secret has been rotated, **When** a user starts a new login after propagation, **Then** login succeeds with the rotated secret and the prior value is no longer accepted.
+
+______________________________________________________________________
+
+### User Story 2 - Resolve token-source conflicts predictably (Priority: P2)
+
+As a homelab operator, I need predictable behavior when token values conflict across sources so I can quickly diagnose and correct access problems.
+
+**Why this priority**: Intermittent failures are often caused by competing token sources; deterministic handling reduces ambiguity and recovery time.
+
+**Independent Test**: Introduce a deliberate mismatch between token sources and verify the system applies a documented precedence rule and records a clear incident reason.
+
+**Acceptance Scenarios**:
+
+1. **Given** conflicting token values are detected, **When** a login attempt occurs, **Then** the system applies a single authoritative source rule and logs the decision context.
+2. **Given** a conflict has been resolved, **When** the next login attempt occurs, **Then** authentication succeeds with the authoritative current value.
+
+______________________________________________________________________
+
+### User Story 3 - Provide operational visibility for token sync health (Priority: P3)
+
+As a homelab operator, I need clear visibility into token sync status and recent auth decisions so I can detect drift before users report outages.
+
+**Why this priority**: Visibility does not directly restore access, but it prevents repeated outages and reduces troubleshooting effort.
+
+**Independent Test**: Review status and event history after normal operation, secret rotation, and conflict conditions to confirm state and timestamps are available and accurate.
+
+**Acceptance Scenarios**:
+
+1. **Given** token sync is healthy, **When** an operator checks status, **Then** they can see an explicit "in sync" state and last verification time.
+2. **Given** token drift is detected, **When** an operator checks status, **Then** they can see an explicit "out of sync" state with a remediation hint.
+
+______________________________________________________________________
+
+### Edge Cases
+
+- Secret value rotates while users still hold active sessions based on the prior token.
+- Temporary unavailability of one token source during sync verification.
+- Repeated rapid secret rotations occurring before the previous rotation fully propagates.
+- Simultaneous login attempts during a detected token conflict window.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST treat a single defined token source as authoritative for Headlamp authentication decisions at any point in time.
+  - **Acceptance Criteria**: For any login attempt, validation is performed against exactly one authoritative source, and that source is identifiable in audit output.
+- **FR-002**: The system MUST synchronize authentication behavior to reflect secret updates for all new login attempts within a bounded propagation window.
+  - **Acceptance Criteria**: After a secret rotation, new logins use the updated value within 5 minutes.
+- **FR-003**: The system MUST detect conflicting token values between active sources and apply a deterministic precedence rule.
+  - **Acceptance Criteria**: During a conflict, the selected value and precedence reason are captured for each impacted decision.
+- **FR-004**: The system MUST expose token sync health status to operators, including state, last successful verification time, and last failure reason when applicable.
+  - **Acceptance Criteria**: Operators can distinguish healthy, degraded, and out-of-sync states without inspecting raw system internals.
+- **FR-005**: The system MUST provide actionable user-facing behavior when token mismatch prevents access.
+  - **Acceptance Criteria**: Failed logins caused by mismatch present a clear message indicating retry expectations or operator follow-up.
+- **FR-006**: The system MUST record auditable events for token synchronization checks, secret rotations observed, conflicts, and authentication outcomes related to token validation.
+  - **Acceptance Criteria**: Operators can retrieve a chronological history of sync and auth events for incident triage.
+- **FR-007**: The system MUST recover automatically from transient sync-check failures and re-validate token consistency without requiring manual restarts.
+  - **Acceptance Criteria**: Following a transient source outage, sync checks resume and state returns to healthy once sources converge.
+
+### Key Entities *(include if feature involves data)*
+
+- **Token Source**: A named origin of token truth (for example, secret store or auth provider view), with attributes for current token fingerprint, last update time, and source priority.
+- **Token Sync State**: The current evaluated relationship between token sources (`in_sync`, `degraded`, `out_of_sync`) with timestamps and reason codes.
+- **Authentication Decision Record**: A per-login outcome including evaluated source, decision result, and failure category (if denied).
+- **Sync Incident**: A grouped operational event describing mismatch detection, duration, affected login attempts, and resolution status.
+
+### Assumptions
+
+- The desired behavior is to prevent stale or conflicting tokens from silently granting or denying access.
+- Existing Headlamp login flow remains in place; this feature improves token consistency and observability around that flow.
+- Operators need clear operational signals and auditability more than end-user customization for this issue.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 99% of valid Headlamp login attempts succeed on the first attempt during normal operation.
+- **SC-002**: 100% of secret rotations are reflected for new login attempts within 5 minutes of the secret update.
+- **SC-003**: Token mismatch-related access incidents are detected and surfaced to operators within 1 minute of occurrence.
+- **SC-004**: Support interventions related to Headlamp token desynchronization decrease by at least 80% over a 30-day period after rollout.

--- a/specs/001-fix-headlamp-token-sync/tasks.md
+++ b/specs/001-fix-headlamp-token-sync/tasks.md
@@ -1,0 +1,184 @@
+______________________________________________________________________
+
+## description: "Task list for Headlamp token sync reliability"
+
+# Tasks: Headlamp Token Sync Reliability
+
+**Input**: Design documents from `/specs/001-fix-headlamp-token-sync/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: No explicit TDD requirement in spec; implementation and validation tasks only.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- Observability app manifests: `kubernetes/apps/observability/...`
+- OAuth policy manifests: `kubernetes/apps/network/envoy-gateway/app/...`
+- Feature docs: `specs/001-fix-headlamp-token-sync/...`
+
+______________________________________________________________________
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare feature-specific manifest scaffolding and ensure all design artifacts are wired for implementation.
+
+- [x] T001 Create token sync manifest scaffolding under `kubernetes/apps/observability/headlamp/app/` (`token-sync-configmap.yaml`, `token-sync-rbac.yaml`, `token-sync-cronjob.yaml`)
+- [x] T002 [P] Create status app scaffolding under `kubernetes/apps/observability/token-sync-status/` (`ks.yaml`, `app/kustomization.yaml`, `app/ocirepository.yaml`, `app/helmrelease.yaml`, `app/httproute.yaml`)
+- [x] T003 [P] Register new status app in `kubernetes/apps/observability/kustomization.yaml`
+
+______________________________________________________________________
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define shared precedence, state storage, and RBAC prerequisites required by all user stories.
+
+**⚠️ CRITICAL**: User story implementation should not begin until these tasks are complete.
+
+- [x] T004 Define global token precedence and reason-code configuration in `kubernetes/apps/observability/headlamp/app/token-sync-configmap.yaml`
+- [x] T005 [P] Define ServiceAccount/Role/RoleBinding for sync checks in `kubernetes/apps/observability/headlamp/app/token-sync-rbac.yaml`
+- [x] T006 [P] Register foundational token sync resources in `kubernetes/apps/observability/headlamp/app/kustomization.yaml`
+- [x] T007 [P] Add shared status persistence contract (ConfigMap layout and retention policy) to `specs/001-fix-headlamp-token-sync/data-model.md`
+- [x] T008 Capture foundational operational checks in `specs/001-fix-headlamp-token-sync/quickstart.md`
+
+**Checkpoint**: Token precedence is declarative, RBAC is in place, and shared state shape is documented.
+
+______________________________________________________________________
+
+## Phase 3: User Story 1 - Keep login access aligned with current secret (Priority: P1) 🎯 MVP
+
+**Goal**: Ensure new Headlamp logins consistently follow the current materialized secret after rotations.
+
+**Independent Test**: Rotate the `headlamp-admin-token` value in 1Password, wait for reconciliation, and verify new login behavior aligns with the rotated value within 5 minutes.
+
+- [x] T009 [US1] Set explicit synchronization window (`refreshInterval`) and target policy in `kubernetes/apps/observability/headlamp/app/externalsecret.yaml`
+- [x] T010 [P] [US1] Ensure secret-change driven rollout behavior in `kubernetes/apps/observability/headlamp/app/helmrelease.yaml` (reloader annotations bound to `headlamp-admin-token`)
+- [x] T011 [US1] Add US1 rotation verification steps and pass/fail criteria to `specs/001-fix-headlamp-token-sync/quickstart.md`
+- [x] T012 [US1] Document authoritative-source rule and expected operator action in `docs/OIDC-TROUBLESHOOTING.md`
+
+**Checkpoint**: Secret rotations are bounded and repeatable, with clear runbook guidance for operators.
+
+______________________________________________________________________
+
+## Phase 4: User Story 2 - Resolve token-source conflicts predictably (Priority: P2)
+
+**Goal**: Detect token-source conflicts and enforce deterministic precedence with auditable incident context.
+
+**Independent Test**: Introduce a token-source mismatch and verify the precedence rule is applied, incident state is recorded, and new decisions follow the selected authoritative source.
+
+- [x] T013 [US2] Implement sync-check execution manifest in `kubernetes/apps/observability/headlamp/app/token-sync-cronjob.yaml` to compare authoritative source fingerprints and emit reason codes
+- [x] T014 [P] [US2] Add conflict incident state object template in `kubernetes/apps/observability/headlamp/app/token-sync-configmap.yaml` (`open`, `mitigating`, `resolved`)
+- [x] T015 [P] [US2] Add precedence metadata and conflict handling notes to `specs/001-fix-headlamp-token-sync/research.md`
+- [x] T016 [US2] Wire cronjob and RBAC resources in `kubernetes/apps/observability/headlamp/app/kustomization.yaml`
+- [x] T017 [US2] Add conflict simulation and expected-resolution steps to `specs/001-fix-headlamp-token-sync/quickstart.md`
+
+**Checkpoint**: Conflicts are handled deterministically and captured with actionable context.
+
+______________________________________________________________________
+
+## Phase 5: User Story 3 - Provide operational visibility for token sync health (Priority: P3)
+
+**Goal**: Expose sync health, source observations, and incidents through operator-visible endpoints and routes.
+
+**Independent Test**: Query `/token-sync/status`, `/token-sync/sources`, and `/token-sync/incidents`, then verify state transitions and timestamps update after normal sync and induced drift.
+
+- [x] T018 [US3] Implement status API deployment values in `kubernetes/apps/observability/token-sync-status/app/helmrelease.yaml` to serve contract endpoints
+- [x] T019 [P] [US3] Configure status API route exposure in `kubernetes/apps/observability/token-sync-status/app/httproute.yaml` behind `envoy-oauth`
+- [x] T020 [P] [US3] Align API payload schemas with contract definitions in `specs/001-fix-headlamp-token-sync/contracts/token-sync.openapi.yaml`
+- [x] T021 [US3] Register status API resources in `kubernetes/apps/observability/token-sync-status/app/kustomization.yaml` and `kubernetes/apps/observability/token-sync-status/ks.yaml`
+- [x] T022 [US3] Add US3 endpoint verification and remediation checks to `specs/001-fix-headlamp-token-sync/quickstart.md`
+
+**Checkpoint**: Operators can observe health and incidents without ad-hoc log inspection.
+
+______________________________________________________________________
+
+## Final Phase: Polish & Cross-Cutting Concerns
+
+**Purpose**: Complete documentation, validation, and delivery readiness.
+
+- [x] T023 [P] Update feature handoff notes and measurable outcomes mapping in `specs/001-fix-headlamp-token-sync/plan.md`
+- [x] T024 [P] Update post-merge validation runbook for token-sync checks in `docs/POST-MERGE-VERIFICATION.md`
+- [x] T025 Run `task lint` from repository root and fix any formatting issues across changed files
+- [x] T026 Run `task dev:validate` from repository root and confirm flux-local renders all resources successfully
+
+______________________________________________________________________
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Phase 1 and blocks all user story work.
+- **US1 (Phase 3)**: Depends on Foundational completion.
+- **US2 (Phase 4)**: Depends on Foundational completion and can start after US1 if using US1 rotation behavior as baseline.
+- **US3 (Phase 5)**: Depends on Foundational completion and US2 state model for incident/status exposure.
+- **Polish (Final)**: Depends on completion of selected user stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent after Foundational.
+- **US2 (P2)**: Independent after Foundational, but operationally benefits from US1 rotation controls.
+- **US3 (P3)**: Depends on US2 incident/state artifacts to expose meaningful visibility.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel.
+- T005, T006, T007, and T008 can run in parallel after T004.
+- In US1, T010 can run in parallel with T009.
+- In US2, T014 and T015 can run in parallel with T013.
+- In US3, T019 and T020 can run in parallel with T018.
+- In Final Phase, T023 and T024 can run in parallel before validation tasks.
+
+______________________________________________________________________
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Set refreshInterval and target policy in kubernetes/apps/observability/headlamp/app/externalsecret.yaml"
+Task: "Ensure reloader annotations in kubernetes/apps/observability/headlamp/app/helmrelease.yaml"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Implement sync-check execution in kubernetes/apps/observability/headlamp/app/token-sync-cronjob.yaml"
+Task: "Add conflict incident state template in kubernetes/apps/observability/headlamp/app/token-sync-configmap.yaml"
+Task: "Update precedence metadata notes in specs/001-fix-headlamp-token-sync/research.md"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "Implement status API values in kubernetes/apps/observability/token-sync-status/app/helmrelease.yaml"
+Task: "Configure API route in kubernetes/apps/observability/token-sync-status/app/httproute.yaml"
+Task: "Align schema in specs/001-fix-headlamp-token-sync/contracts/token-sync.openapi.yaml"
+```
+
+______________________________________________________________________
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (Setup).
+2. Complete Phase 2 (Foundational).
+3. Complete Phase 3 (US1).
+4. Validate rotation behavior with quickstart criteria.
+
+### Incremental Delivery
+
+1. Deliver US1 for immediate login reliability gains.
+2. Deliver US2 for deterministic conflict handling and incident capture.
+3. Deliver US3 for operator visibility endpoints and monitoring workflows.
+4. Run final validation and update runbooks.
+
+### Suggested MVP Scope
+
+- **MVP**: Through Phase 3 (US1) plus validation tasks T025-T026.
+- **Post-MVP**: US2 and US3 in subsequent increments.


### PR DESCRIPTION
## Summary
- make Kubernetes headlamp-admin-token the explicit runtime authority for Headlamp token decisions
- add token sync manifests (config, RBAC, cron check) and a token-sync-status app with token-sync endpoints behind envoy-oauth
- update runbooks/spec docs and complete validation flow (task lint, task dev:validate)

## Validation
- task lint
- task dev:validate

## Notes
- branch testing flow started with task dev:start; remember to run task dev:stop after testing