### PR TITLE
🔐 OAuth admin/users gateway groups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,10 @@ Use `kubernetes/apps/default/echo/` as a working reference. After adding files:
 **If the app is OAuth-protected**:
 
 1. Add an explicit hostname entry in
-   `kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml` that routes to
-   `https://envoy-oauth.<namespace>.svc.cluster.local:443` **before** the wildcard
-   `*.${SECRET_DOMAIN}` rule.
+   `kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml` **before** the wildcard
+   `*.${SECRET_DOMAIN}` rule. Route by group:
+   - admins: `https://envoy-oauth-admin.<namespace>.svc.cluster.local:443` with `originServerName: oauth.${SECRET_DOMAIN}`
+   - users: `https://envoy-oauth-users.<namespace>.svc.cluster.local:443` with `originServerName: oauth-users.${SECRET_DOMAIN}`
 2. Add the app hostname to
    `kubernetes/apps/default/oauth-pages/app/httproute.yaml` so `/denied` and `/logged-out` work on
    that host.

--- a/docs/GATEWAY-ONBOARDING-CHECKLIST.md
+++ b/docs/GATEWAY-ONBOARDING-CHECKLIST.md
@@ -6,7 +6,7 @@ ______________________________________________________________________
 
 ## 1. Design Inputs
 
-- [ ] Pick gateway name (`envoy-oauth` or `envoy-oauth-<group>`)
+- [ ] Pick gateway name (`envoy-oauth-admin` or `envoy-oauth-<group>`)
 - [ ] Reserve unique LB IP from MetalLB/Cilium IPAM pool
 - [ ] Pick DNS hostname under `${SECRET_DOMAIN}`
 - [ ] Decide external vs internal DNS target annotation

--- a/docs/GOOGLE-OAUTH-SETUP.md
+++ b/docs/GOOGLE-OAUTH-SETUP.md
@@ -22,6 +22,7 @@ ______________________________________________________________________
 3. Choose **Web application**
 4. Add authorized redirect URIs for each OAuth Gateway:
    - `https://oauth.<YOUR_DOMAIN>/oauth2/callback`
+   - `https://oauth-users.<YOUR_DOMAIN>/oauth2/callback` (users group gateway)
    - `https://oauth-internal.<YOUR_DOMAIN>/oauth2/callback` (if using internal gateway)
 5. Save and copy the Client ID + Client Secret
 
@@ -47,6 +48,13 @@ Store in:
 
 - `kubernetes/apps/network/envoy-gateway/app/oauth-policy.sops.yaml`
 - `kubernetes/apps/network/envoy-gateway/app/oauth-policy-internal.sops.yaml` (if used)
+
+`oauth-policy.sops.yaml` contains both external group policies:
+
+- `envoy-oauth-admin-policy` (admins)
+- `envoy-oauth-users-policy` (users; include admin emails in this list too)
+
+There are only two external email lists to maintain: admins and users.
 
 Field:
 
@@ -76,7 +84,8 @@ sops --encrypt /tmp/oauth-policy.yaml > kubernetes/apps/network/envoy-gateway/ap
 rm /tmp/oauth-policy.yaml
 ```
 
-Use the same flow for `oauth-policy-internal.sops.yaml` and `oauth-client-secret.sops.yaml`.
+Use the same flow for `oauth-policy.sops.yaml`, `oauth-policy-internal.sops.yaml`, and
+`oauth-client-secret.sops.yaml`.
 
 ______________________________________________________________________
 
@@ -104,8 +113,8 @@ For branch testing:
 
 ```bash
 task dev:start
-kubectl get gateway -n network envoy-oauth envoy-oauth-internal --show-labels
-kubectl get securitypolicy -n network envoy-oauth-policy envoy-oauth-internal-policy
+kubectl get gateway -n network envoy-oauth-admin envoy-oauth-users envoy-oauth-internal --show-labels
+kubectl get securitypolicy -n network envoy-oauth-admin-policy envoy-oauth-users-policy envoy-oauth-internal-policy
 task dev:stop
 ```
 

--- a/docs/OIDC-TROUBLESHOOTING.md
+++ b/docs/OIDC-TROUBLESHOOTING.md
@@ -7,8 +7,8 @@ ______________________________________________________________________
 ## Quick Triage
 
 ```bash
-kubectl get gateway -n network envoy-oauth envoy-oauth-internal --show-labels
-kubectl get securitypolicy -n network envoy-oauth-policy envoy-oauth-internal-policy
+kubectl get gateway -n network envoy-oauth-admin envoy-oauth-users envoy-oauth-internal --show-labels
+kubectl get securitypolicy -n network envoy-oauth-admin-policy envoy-oauth-users-policy envoy-oauth-internal-policy
 kubectl get securitypolicy -n default oauth-pages-public -o yaml
 kubectl get secret -n network google-oauth-client-secret
 kubectl get httproute -n default oauth-pages
@@ -30,7 +30,7 @@ ______________________________________________________________________
 ### Check
 
 ```bash
-kubectl get gateway -n network envoy-oauth envoy-oauth-internal --show-labels
+kubectl get gateway -n network envoy-oauth-admin envoy-oauth-users envoy-oauth-internal --show-labels
 kubectl get helmrelease -n network cloudflare-dns -o yaml | grep gateway-label-filter
 ```
 
@@ -55,17 +55,15 @@ ______________________________________________________________________
 - Redirect URI is registered in Google OAuth client
 - `oauth-pages` includes the exact `/oauth2/callback` route
 - `oauth-pages-public` policy does **not** broadly allow the callback route
-- `cloudflare-tunnel` has an explicit `oauth.${SECRET_DOMAIN}` ingress entry to `envoy-oauth`
-  before `*.${SECRET_DOMAIN}` in
-  `kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml`
+- `cloudflare-tunnel` has explicit OAuth host ingress entries before `*.${SECRET_DOMAIN}`:
+  - `oauth.${SECRET_DOMAIN}` -> `envoy-oauth-admin`
+  - `oauth-users.${SECRET_DOMAIN}` -> `envoy-oauth-users`
 
-Primary policy file:
+Policy files:
 
 - `kubernetes/apps/network/envoy-gateway/app/oauth-policy.sops.yaml`
-
-Secondary policy file:
-
-- `kubernetes/apps/network/envoy-gateway/app/oauth-policy-internal.sops.yaml`
+  (contains both `envoy-oauth-admin-policy` for admins and `envoy-oauth-users-policy` for users)
+- `kubernetes/apps/network/envoy-gateway/app/oauth-policy-internal.sops.yaml` (internal)
 
 ### Fix
 
@@ -73,8 +71,8 @@ Secondary policy file:
 - Ensure callback handling stays on the OIDC flow:
   - `oauth-pages` route rule `callback` matches `/oauth2/callback`
   - `oauth-pages-public` only targets `sectionName: denied` and `sectionName: logged-out`
-- Ensure `cloudflare-tunnel` sends `oauth.${SECRET_DOMAIN}` to `envoy-oauth` with an explicit
-  hostname rule before the wildcard route
+- Ensure `cloudflare-tunnel` sends OAuth hostnames to the matching OAuth Gateway services with
+  explicit hostname rules before the wildcard route
 - Re-encrypt SOPS file if edited in plaintext
 - Push and reconcile
 
@@ -109,7 +107,8 @@ kubectl get httproute -n default oauth-pages -o yaml
 
 ### Expected
 
-- `parentRefs` include both `envoy-oauth` and `envoy-oauth-internal` (and `envoy-external` if used)
+- `parentRefs` include `envoy-oauth-admin`, `envoy-oauth-users`, and `envoy-oauth-internal`
+  (and `envoy-external` if used)
 - route rules include exact `/denied` and `/logged-out`
 - rules rewrite to `/denied.html` and `/logged-out.html`
 - `oauth-pages-public` allows only `sectionName: denied` and `sectionName: logged-out`
@@ -127,7 +126,7 @@ ______________________________________________________________________
 ### Check
 
 ```bash
-kubectl get gateway -n network envoy-oauth envoy-oauth-internal -o wide
+kubectl get gateway -n network envoy-oauth-admin envoy-oauth-users envoy-oauth-internal -o wide
 kubectl get secret -n network <secret-domain-production-tls-secret>
 ```
 

--- a/docs/POST-MERGE-VERIFICATION.md
+++ b/docs/POST-MERGE-VERIFICATION.md
@@ -7,8 +7,8 @@ ______________________________________________________________________
 ## 1. Reconciliation and Resource Presence
 
 ```bash
-kubectl get gateway -n network envoy-oauth envoy-oauth-internal
-kubectl get securitypolicy -n network envoy-oauth-policy envoy-oauth-internal-policy
+kubectl get gateway -n network envoy-oauth-admin envoy-oauth-users envoy-oauth-internal
+kubectl get securitypolicy -n network envoy-oauth-admin-policy envoy-oauth-users-policy envoy-oauth-internal-policy
 kubectl get httproute -n default oauth-pages
 kubectl get helmrelease -n network cloudflare-dns
 ```
@@ -24,12 +24,12 @@ ______________________________________________________________________
 
 ## 2. DNS and TLS Sanity
 
-- [ ] OAuth hostnames resolve (`oauth.<domain>`, `oauth-internal.<domain>`)
-- [ ] TLS certificate is served for both hosts
+- [ ] OAuth hostnames resolve (`oauth.<domain>`, `oauth-users.<domain>`, `oauth-internal.<domain>`)
+- [ ] TLS certificate is served for all OAuth hosts
 - [ ] Gateway labels still include `home-ops.io/cloudflare-dns=true`
 
 ```bash
-kubectl get gateway -n network envoy-oauth envoy-oauth-internal --show-labels
+kubectl get gateway -n network envoy-oauth-admin envoy-oauth-users envoy-oauth-internal --show-labels
 ```
 
 ______________________________________________________________________

--- a/docs/SECURITYPOLICY-CHANGE-PLAYBOOK.md
+++ b/docs/SECURITYPOLICY-CHANGE-PLAYBOOK.md
@@ -9,6 +9,7 @@ ______________________________________________________________________
 Primary files:
 
 - `kubernetes/apps/network/envoy-gateway/app/oauth-policy.sops.yaml`
+  - contains `envoy-oauth-admin-policy` (admins) and `envoy-oauth-users-policy` (users)
 - `kubernetes/apps/network/envoy-gateway/app/oauth-policy-internal.sops.yaml`
 
 Related secret:
@@ -30,6 +31,8 @@ sops --decrypt kubernetes/apps/network/envoy-gateway/app/oauth-policy.sops.yaml 
 - Keep `authorization.defaultAction: Deny`
 - Keep `email_verified=true` check
 - Add/remove only lowercase emails in `email` claim values
+- Keep two external lists only: admins (`envoy-oauth-admin-policy`) and users (`envoy-oauth-users-policy`)
+- Include admin emails in the users list when admins should also have users access
 
 ## 3) Re-encrypt and clean up
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -137,9 +137,9 @@ task lint
 task dev:validate
 task dev:start
 
-kubectl get gateway -n network envoy-oauth envoy-oauth-internal
-kubectl get gateway -n network envoy-oauth envoy-oauth-internal --show-labels
-kubectl get securitypolicy -n network envoy-oauth-policy envoy-oauth-internal-policy
+kubectl get gateway -n network envoy-oauth-admin envoy-oauth-users envoy-oauth-internal
+kubectl get gateway -n network envoy-oauth-admin envoy-oauth-users envoy-oauth-internal --show-labels
+kubectl get securitypolicy -n network envoy-oauth-admin-policy envoy-oauth-users-policy envoy-oauth-internal-policy
 kubectl get httproute -n default oauth-pages
 
 # manual/browser checks:

--- a/kubernetes/apps/default/oauth-pages/app/httproute.yaml
+++ b/kubernetes/apps/default/oauth-pages/app/httproute.yaml
@@ -7,7 +7,9 @@ metadata:
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
 spec:
   parentRefs:
-    - name: envoy-oauth
+    - name: envoy-oauth-admin
+      namespace: network
+    - name: envoy-oauth-users
       namespace: network
     - name: envoy-oauth-internal
       namespace: network
@@ -15,6 +17,7 @@ spec:
       namespace: network
   hostnames:
     - oauth.${SECRET_DOMAIN}
+    - oauth-users.${SECRET_DOMAIN}
     - oauth-internal.${SECRET_DOMAIN}
     - grafana.${SECRET_DOMAIN}
     - headlamp.${SECRET_DOMAIN}

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -71,8 +71,8 @@ spec:
               - hostname: "grafana.${SECRET_DOMAIN}"
                 originRequest:
                   http2Origin: true
-                  originServerName: oauth.${SECRET_DOMAIN}
-                service: https://envoy-oauth-admin.{{ .Release.Namespace }}.svc.cluster.local:443
+                  originServerName: oauth-users.${SECRET_DOMAIN}
+                service: https://envoy-oauth-users.{{ .Release.Namespace }}.svc.cluster.local:443
               - hostname: "headlamp.${SECRET_DOMAIN}"
                 originRequest:
                   http2Origin: true

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -72,17 +72,22 @@ spec:
                 originRequest:
                   http2Origin: true
                   originServerName: oauth.${SECRET_DOMAIN}
-                service: https://envoy-oauth.{{ .Release.Namespace }}.svc.cluster.local:443
+                service: https://envoy-oauth-admin.{{ .Release.Namespace }}.svc.cluster.local:443
               - hostname: "headlamp.${SECRET_DOMAIN}"
                 originRequest:
                   http2Origin: true
                   originServerName: oauth.${SECRET_DOMAIN}
-                service: https://envoy-oauth.{{ .Release.Namespace }}.svc.cluster.local:443
+                service: https://envoy-oauth-admin.{{ .Release.Namespace }}.svc.cluster.local:443
               - hostname: "oauth.${SECRET_DOMAIN}"
                 originRequest:
                   http2Origin: true
                   originServerName: oauth.${SECRET_DOMAIN}
-                service: https://envoy-oauth.{{ .Release.Namespace }}.svc.cluster.local:443
+                service: https://envoy-oauth-admin.{{ .Release.Namespace }}.svc.cluster.local:443
+              - hostname: "oauth-users.${SECRET_DOMAIN}"
+                originRequest:
+                  http2Origin: true
+                  originServerName: oauth-users.${SECRET_DOMAIN}
+                service: https://envoy-oauth-users.{{ .Release.Namespace }}.svc.cluster.local:443
               - hostname: "*.${SECRET_DOMAIN}"
                 originRequest:
                   http2Origin: true

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -194,7 +194,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: envoy-oauth
+  name: envoy-oauth-admin
   namespace: network
   labels:
     home-ops.io/cloudflare-dns: "true"
@@ -207,6 +207,39 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: oauth.${SECRET_DOMAIN}
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: ${SECRET_DOMAIN/./-}-production-tls
+            namespace: network
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: envoy-oauth-users
+  namespace: network
+  labels:
+    home-ops.io/cloudflare-dns: "true"
+    home-ops.io/oauth-gateway: "true"
+  annotations:
+    external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+    lbipam.cilium.io/ips: "192.168.1.151"
+spec:
+  gatewayClassName: envoy
+  infrastructure:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: oauth-users.${SECRET_DOMAIN}
   listeners:
     - name: http
       protocol: HTTP
@@ -271,7 +304,10 @@ spec:
     - name: envoy-internal
       namespace: network
       sectionName: http
-    - name: envoy-oauth
+    - name: envoy-oauth-admin
+      namespace: network
+      sectionName: http
+    - name: envoy-oauth-users
       namespace: network
       sectionName: http
     - name: envoy-oauth-internal

--- a/kubernetes/apps/network/envoy-gateway/app/oauth-policy.sops.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/oauth-policy.sops.yaml
@@ -5,50 +5,50 @@ metadata:
   namespace: network
 spec:
   targetRefs:
-    - group: ENC[AES256_GCM,data:oLjhxYVlKopwEw540uxwDXiSkJBTVo2HRw==,iv:H7e8rsek39HfvNKlig1+Om3kWYlPKeKJsbLQmhUO/uM=,tag:yL4G7k4E0Po9jb8tILJd2g==,type:str]
-      kind: ENC[AES256_GCM,data:sHqFwBa9sw==,iv:gRWPcEM/68KqNSGMEnlvptzydoCuCSnXXYmcg6bJXfQ=,tag:xHk/K3Z8SHrjGKB0aGdKzQ==,type:str]
+    - group: ENC[AES256_GCM,data:X1c8MGWB0ooBmsKtyDTMqRqhXTJaPcmXdg==,iv:BNalln77VdN7bDNTnDtG8rD7ebafwUvlCQ6OAVpEfRU=,tag:NzxTTA7xMx3M67EJn+hbtw==,type:str]
+      kind: ENC[AES256_GCM,data:fZmyLJITYw==,iv:S2p0Ndi394k0BXFXoi3C9tNhi6zN1GcZdI2SmE6dQfA=,tag:UkLxQMQZDh5l0t4XRsgeAQ==,type:str]
       name: ENC[AES256_GCM,data:GG7+y2Hcr4Bw57Zz/E6q3pY=,iv:SoZi1Oi9o4SslmFtxgLXHbDz/7ONDgXZWVOp61xTvNY=,tag:4guewQ03fxU9o+z2zvqO/A==,type:str]
   oidc:
     provider:
-      issuer: ENC[AES256_GCM,data:5Bq2ijva17M8zKazGGXVuvkA1A2019PQm/cO,iv:ca3UQQrLmiz21D4gHlTknsclDVePoLnDAsnRq98fajY=,tag:zaa8zq3QvqOIuRA0vkz5/A==,type:str]
-      authorizationEndpoint: ENC[AES256_GCM,data:bkXW7pOiUa8cex+PhAsu2fcoSWO0zrOuG7XRVbAxDAGmOPJ+qQ7e/f70u1kwEZocshtdBaoQzRpZqzzEB8qQq0YU,iv:9rCCkg5+mxex37S/jfYNzfG78Ukg6fcZGDf4vcOCthc=,tag:0kK1uKlLBPDarxvA6QMhGw==,type:str]
-    clientID: ENC[AES256_GCM,data:z9SurScgpZayuj4V199Qy+hqJlkg+KD/BtPFRDfS/RQrIwQr6OHNeMpp3plcHEhurRD4sY2ZdZApAmGFT/1pGCNYQmvYB4Jx,iv:TzI4os5oncMsQ4JJXlOI46Se0OF7C/U9W5AYN7g4Zj8=,tag:7OjMx6L2W6NjSF5CZay23Q==,type:str]
+      issuer: ENC[AES256_GCM,data:HY4va89EQhz0xkFDqcDs8rur/FcCbdbTrrex,iv:N1ANjBOwePOQR6FxVWOW4mSZmNuw2kBD8xDj+3g7eiM=,tag:a5BrchlgrNlOBp1KVR+6uQ==,type:str]
+      authorizationEndpoint: ENC[AES256_GCM,data:rqoSCgWroIMkpnoISWt04vNF/VuCA6JA9RitR+2XZs1Y6n5LM7L0cxmYbtfiG5EeEGBpw+JtBrrWm8ZL/Xlz4Nr7,iv:AWuGgEDU5rvI0tm88U12t25Glx9o0C+xwQ+SxSWBO2s=,tag:KgSRZLjOAqK+DSkpmFl2aw==,type:str]
+    clientID: ENC[AES256_GCM,data:U14q5ttWiB7RyoezR0vqr/dlrg3tTMQDvaSV3Jhc8ZCrhPmN0J0Tad5XpwfTbB6/ck2BRuJWwKKXObTegUqU0xOm8PuFmV2R,iv:URX7+cDv1X4OA0iQHXlghG4GiUWvW4mcOH/TQ8vKEyg=,tag:KZwb6+hhwjxQx8iwv7qc4A==,type:str]
     clientSecret:
-      name: ENC[AES256_GCM,data:49F8uyOglo08wGzOjblfz7oVUZcns/hO+7k=,iv:mrb7BTQHve27nn/NPmceU119fG2FOKARUuxRTs4nylk=,tag:7cVc2b6x6nvBvU6zwSkppw==,type:str]
-      namespace: ENC[AES256_GCM,data:OYjOVe6RpA==,iv:hqM/SBLlZ+zUs0sW587gCQaKEX7zdpMzA0+GBmOE9VU=,tag:4R95Qdiux3SgOhX2vCvkcg==,type:str]
+      name: ENC[AES256_GCM,data:IrmSUNOm2u+aiIzm8ZWAYm+wy2iUCoQm+Zo=,iv:Gk7BsQSFx2wud79E83z3dMfNtE7u+pV+zxjQd2p9tEg=,tag:bv/bzaB4zJO1G0FgajQzZg==,type:str]
+      namespace: ENC[AES256_GCM,data:O3047/RQRg==,iv:Byph8ETsmn8dKK9BoUPfpbp74PN1SIEUTPxlw1fvfH4=,tag:oOEFsOr35Nb0LdE71e5XZg==,type:str]
     redirectURL: ENC[AES256_GCM,data:jalqWyUwAlegeuAQtcKAABH1Ze9z9VMc2jCePcHB5TPry0ZTX9c025wS5Y1XYg==,iv:GiY47eNTm1yvYJdVe9S4c4pzsMpoh93f/a0wjlyeMmA=,tag:SsZG71w3FAxjBnfPWh17ag==,type:str]
-    logoutPath: ENC[AES256_GCM,data:QLwzhS3c2g==,iv:Qfk1Oz26Z1lZuZIGoT5kGV/3zgFmG9t7HHhEOIWuscU=,tag:q1GxqIq/Y/c6sbwfF/SvhQ==,type:str]
-    cookieDomain: ENC[AES256_GCM,data:ooqY6mPn/9KK1CLSe0uE3g==,iv:T/9+DRbSSmT0y9iPtTZFTVV/bSoTLqXs7+I4I+l2+Xo=,tag:sij0jpouV3L70+UW+xaovQ==,type:str]
+    logoutPath: ENC[AES256_GCM,data:43S/ecUjPQ==,iv:AuciVK+8HgbWs1svFCn5AvwFXMmBOxSoOm8EsYto5Gg=,tag:7h4woUj/XTux/n8vfrykVg==,type:str]
+    cookieDomain: ENC[AES256_GCM,data:McpS0H3HQuVIckEipn/Sjg==,iv:ji73imcXtAZ8uKbPc01ifumIQO6T74FzIXo/HpIXv2w=,tag:CQ/L3GA2xkmy3lN4WnNLNQ==,type:str]
     cookieNames:
-      accessToken: ENC[AES256_GCM,data:agtwTgyL/M/R5Kg=,iv:hedDC/6ln13Iv6oXtCAlJuytXOBfpILvDbsLdFbGRfQ=,tag:W5nqQkjNsiTw/ZCEXH4Lxw==,type:str]
-      idToken: ENC[AES256_GCM,data:2sbjFAS0Cg==,iv:z8EHmfGfduSJo/NcdGLiyz4jSpoExTW3XsYNUfMRjm0=,tag:Uo97WZTqG+OTFp+rAdjrxw==,type:str]
+      accessToken: ENC[AES256_GCM,data:XVdqdcGZoqlR3+o=,iv:LtLCrCk6SzQezUughTSqCO+Ndx+xAmh7z0Qa3EE+IO4=,tag:7Z7Cutj6YLwLNcTpyqmdcw==,type:str]
+      idToken: ENC[AES256_GCM,data:gcNvEylj7A==,iv:/LdSEhyOaH2UzrU/K5nTaEP8Goi6pdK9C9w+6+yqLAs=,tag:lrT10551yHkM6mrBzoTpgA==,type:str]
     scopes:
-      - ENC[AES256_GCM,data:mbqVkbHz,iv:UhDSwkUZR6lB2L9/xIRL3wOa3lADL8CtJf+AM5MMk7w=,tag:cYc/DqSWOu3vu1dB1A2ngA==,type:str]
-      - ENC[AES256_GCM,data:vcoAXc4=,iv:Rxb/tOyd9u53y9mTPV9LaEMpXPN6hZmiWCVRZ2zdSgw=,tag:WIHS3SysQY87Be6DP/31Nw==,type:str]
-      - ENC[AES256_GCM,data:zGxjenIOnA==,iv:61FS3ycFj+Y12QiYGsvhPxCxmT72Yf2lXAd6praMiBw=,tag:UNxWbE5XqGxrg2eNB1ix9g==,type:str]
+      - ENC[AES256_GCM,data:P8CQ3DXu,iv:qM6R5zpTqsNJBMRHKyipIe+NPAjMm84M+/FE4fN27fQ=,tag:uGGbkpu7O2UG6lZHZWxxkQ==,type:str]
+      - ENC[AES256_GCM,data:zwmYiZg=,iv:49nuIapCaUDsGIiqWYzggT+9uN4Em02JfwSyeZR7g7Q=,tag:/OqqNBbqtJP6wVSsPJmuRw==,type:str]
+      - ENC[AES256_GCM,data:uUOJ2kBi7g==,iv:ijGqDTgSv38Mqd2JIuf4borlFvVcAe2HQs/UbSs7MSw=,tag:kmERBAT8RKBENt92C3EzBw==,type:str]
   jwt:
     providers:
-      - name: ENC[AES256_GCM,data:kWGYa63J,iv:BKKz2G0IeLZG+7Qjm0OcGtfYP5o4sVb+gKwVswoSSQI=,tag:lV/JSGuuuJvjbsrhNteDpA==,type:str]
-        issuer: ENC[AES256_GCM,data:M6TC/nT6le5oneZhYUzGVTNw4jQX++5ccfO0,iv:v42TsU8j0f/bOiESq8rK9XrTbwGeaN30sfIPPyXTZ2I=,tag:6rlaiOefPe8iC6PX2c0pcA==,type:str]
+      - name: ENC[AES256_GCM,data:LkULw5YR,iv:iOnrfUADbbGCmvW8D++ZBwQXJFllRqkH/TxfANsmW5Q=,tag:i13MALZSnEiV8hJnsJbmaA==,type:str]
+        issuer: ENC[AES256_GCM,data:DA0RSmxoZqfnrl4nnr/4xniGTCg3f0opejSG,iv:ruZnCSTXohIc3jF/66O1FYHhYVtujFYnIKKRhckF4OU=,tag:pUQbXvxsA5XAOcbVT/nijQ==,type:str]
         remoteJWKS:
-          uri: ENC[AES256_GCM,data:GvaX1H7C2s4VqFvqXt+2Z7oWcTAnq/vYSnnwXCWoM0d0JrxDY8k5kTQ5,iv:IKxBCmqH9K6VkzXAU2gQV71nxtmh0RDJSAP1TyOTVZM=,tag:2eFSCSvjFehK0o0j/9Mxwg==,type:str]
+          uri: ENC[AES256_GCM,data:8SYiu3qwiQTux6jHye7O+9U6bWkXjZaHqC3R//Da6DhpnIWyi9/KA1gs,iv:hRYmTGWDzeYfpc16IZdnixr+lYx7phH0TJymQZIJqDc=,tag:hXwL7JZFeYjMwkGVUblUaA==,type:str]
         extractFrom:
           cookies:
-            - ENC[AES256_GCM,data:4nZ1IVhl+g==,iv:VwAm5lab9o8HoH19TGFtGpp7PwvG77vwTEDMy5XVTgk=,tag:nCEobHtLjnJFLSgiIRLiKw==,type:str]
+            - ENC[AES256_GCM,data:HvmE/Te5eg==,iv:xYwmlWsO0caAZGXS1b6eVlwLyDnBbdxBsZk6KdAoits=,tag:A+6XbXG7eu70CVT6o3nuuQ==,type:str]
           params:
-            - ENC[AES256_GCM,data:UIIB2MhRKMvnvwRv,iv:1BV6p7WW1uJeFe0L7dNP81WWRVJqHuxGnuRfViKBKr8=,tag:RsFD5VRQQnUkg0b7wvnnLA==,type:str]
+            - ENC[AES256_GCM,data:uX36x4DNqh/qnhtN,iv:onO9yRrf2ZJLTkAO5C1VvjPIwI11shuYw5FLK0Q2Pqg=,tag:y5A61mB5Q1xO2jX7pv6xYA==,type:str]
   authorization:
-    defaultAction: ENC[AES256_GCM,data:LzZOmg==,iv:MvzrWn11edTpbnSXHQhD26voqLoagUS4d0ef5TF1jDU=,tag:IYd0jyCBvvbhhNs6ebMstA==,type:str]
+    defaultAction: ENC[AES256_GCM,data:MKsUnA==,iv:Eez9I2Cko/BFUiG3X9XFna3QRwr4DAN4HSMCZGKZUlI=,tag:nOX5YbJSFBo4DG7QZwQLyA==,type:str]
     rules:
       - name: ENC[AES256_GCM,data:873tn0gLc1bGiDyGTkL3,iv:dkTESaN7qTPtdEX9T6PZgKkBfEzGYULUnWCE1sthz+Q=,tag:4ZOHj5O49+DbMYJ7+j5HrQ==,type:str]
-        action: ENC[AES256_GCM,data:sWauDUI=,iv:IZk1t38l6x36eEfUllZJFK0gAB3ttsb64WpM7nzgJAc=,tag:ikX3yXM5WZYhbmOMIDceuw==,type:str]
+        action: ENC[AES256_GCM,data:SNhIUec=,iv:4A4cPHR45IknFJzbcikOniNa9sgdx70Dld/hI4paOI4=,tag:VNoNT8FfGt3NE/iNAgyHzw==,type:str]
         principal:
           jwt:
-            provider: ENC[AES256_GCM,data:1UZ+nkJ0,iv:gqIyCz3SfgGsR2vVWpyZ97Gc3YmZU+zoCfuFqTxqkWI=,tag:yuV+E/U4ED14HOrL33EUAg==,type:str]
+            provider: ENC[AES256_GCM,data:7ducz3af,iv:NcEI0/OujXzVC2z8OU28yN0jpx1i7w+smrSWU8nLO50=,tag:E0l8LNREWCpPEnGwi0/iNw==,type:str]
             claims:
-              - name: ENC[AES256_GCM,data:bcYWyAY=,iv:iCHvMMfugHKJBA4VY0o2BWNQHzmwlS6cVVo+VPRXQQw=,tag:NJttYLby+1n7aC+tdaKEdw==,type:str]
+              - name: ENC[AES256_GCM,data:ASSYR/s=,iv:u6jW4RT9JvW0U6t0ss37GhWIp3ZDJ0MSVY8Lgj5mAIM=,tag:qtXY4uGMKxJriyi0048/yA==,type:str]
                 values:
-                  - ENC[AES256_GCM,data:3VA2C3CgvPhaIKbQUxgJDA==,iv:4BJxghwpI258EplHG7S5Bel9pz9un4UehbrJonY6+lw=,tag:FNaUBQTsAv5t7EcZ9FONMQ==,type:str]
+                  - ENC[AES256_GCM,data:TWkm9BcoP9tADsKRx06Stg==,iv:yM0kB+R3lcaPDl2fRzhQFNhliJnrXfjQpEIQk37ONn0=,tag:jFjjqy6xQP3r/ZlNogsoeA==,type:str]
 sops:
   age:
     - recipient: age1d7ltdyge970mha3gqyenf9mrn8ezg60nexy99vzndvl592q2zcxqkytdwd
@@ -60,8 +60,8 @@ sops:
         ZjIwR1BKcmVqeHdLWHJoMTRSNEw5TDgKgDJuI2KnAqHrJE1ZOcA+67oSZ3RikOL4
         J7I4KhE8KRc2pMj8LnFD3+xqTUvawiLpQcGQ/lizZ/6BuBlFP6g35Q==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-12T04:49:00Z"
-  mac: ENC[AES256_GCM,data:W9afEg6YaIyoo05K0Lwljq3Ar3oltxqpMFpv6TMR/Dh67g2+kSxMo4w3MZa4f3uWYCbJKhoyEX4BKox2Z6pRIvQHTkSe6r+9Aag46H2B5OKbt12aPO0HfPi6FLXeQlRsy7c2REw6n1N934ePVEedk95cTnD2jn6P+GU2Qac1RPw=,iv:Lh1TNct5MNh8slHCjW3oUP8ALd8dQxN+kyqAyZpBPlY=,tag:9ZlZuskijb1laAZW3Ewpiw==,type:str]
+  lastmodified: "2026-03-12T04:54:35Z"
+  mac: ENC[AES256_GCM,data:co9gXDpQfs8KcRON5vxl5ogNcErH77ym83jRASKS8iqiUh8wXYp9DcFjG8gZBz50sD32XVtJfRoHBBwOJsBNNrCatZcMUxqkq6GSrKg02kmt4k8ih+Yq5Im4lGqpmPVZOdnH/zGj+z+ty7ohfkVr942dyo6DxY7L73+2z2PNibQ=,iv:1EZXYfDuHUY38ooiN22gTop6go3FRfCwOPJAHVHiV6o=,tag:xwvW7wJHSanb7aY29gYi9Q==,type:str]
   encrypted_regex: ^(spec)$
   mac_only_encrypted: true
   version: 3.12.1
@@ -117,6 +117,7 @@ spec:
               - name: ENC[AES256_GCM,data:ASSYR/s=,iv:u6jW4RT9JvW0U6t0ss37GhWIp3ZDJ0MSVY8Lgj5mAIM=,tag:qtXY4uGMKxJriyi0048/yA==,type:str]
                 values:
                   - ENC[AES256_GCM,data:TWkm9BcoP9tADsKRx06Stg==,iv:yM0kB+R3lcaPDl2fRzhQFNhliJnrXfjQpEIQk37ONn0=,tag:jFjjqy6xQP3r/ZlNogsoeA==,type:str]
+                  - ENC[AES256_GCM,data:K7vZ7L/rPcrkG2ikIMUXByaU2DNeA6BB2RM=,iv:eTZq/QSKbMGV1Zh6ecs6+vKQGdiUFIbdO0DxYgVn4fw=,tag:kLLU0dJd+LXcVNdHamJEMQ==,type:str]
 sops:
   age:
     - recipient: age1d7ltdyge970mha3gqyenf9mrn8ezg60nexy99vzndvl592q2zcxqkytdwd
@@ -128,8 +129,8 @@ sops:
         ZjIwR1BKcmVqeHdLWHJoMTRSNEw5TDgKgDJuI2KnAqHrJE1ZOcA+67oSZ3RikOL4
         J7I4KhE8KRc2pMj8LnFD3+xqTUvawiLpQcGQ/lizZ/6BuBlFP6g35Q==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-12T04:49:00Z"
-  mac: ENC[AES256_GCM,data:W9afEg6YaIyoo05K0Lwljq3Ar3oltxqpMFpv6TMR/Dh67g2+kSxMo4w3MZa4f3uWYCbJKhoyEX4BKox2Z6pRIvQHTkSe6r+9Aag46H2B5OKbt12aPO0HfPi6FLXeQlRsy7c2REw6n1N934ePVEedk95cTnD2jn6P+GU2Qac1RPw=,iv:Lh1TNct5MNh8slHCjW3oUP8ALd8dQxN+kyqAyZpBPlY=,tag:9ZlZuskijb1laAZW3Ewpiw==,type:str]
+  lastmodified: "2026-03-12T04:54:35Z"
+  mac: ENC[AES256_GCM,data:co9gXDpQfs8KcRON5vxl5ogNcErH77ym83jRASKS8iqiUh8wXYp9DcFjG8gZBz50sD32XVtJfRoHBBwOJsBNNrCatZcMUxqkq6GSrKg02kmt4k8ih+Yq5Im4lGqpmPVZOdnH/zGj+z+ty7ohfkVr942dyo6DxY7L73+2z2PNibQ=,iv:1EZXYfDuHUY38ooiN22gTop6go3FRfCwOPJAHVHiV6o=,tag:xwvW7wJHSanb7aY29gYi9Q==,type:str]
   encrypted_regex: ^(spec)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/network/envoy-gateway/app/oauth-policy.sops.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/oauth-policy.sops.yaml
@@ -1,67 +1,135 @@
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  name: envoy-oauth-policy
+  name: envoy-oauth-admin-policy
   namespace: network
 spec:
   targetRefs:
-    - group: ENC[AES256_GCM,data:O9aECoSeckDU+Oq5meKKlKpvcykVShNPlw==,iv:D09NwPeIF2DA6v5gjodXo0CQTXT03q8v6A6DvZyRRoU=,tag:mKHmgCwOMZx2dr9lI1XnZA==,type:str]
-      kind: ENC[AES256_GCM,data:rWwg9hA0gQ==,iv:H6mj4HxObIejncpT+kj82zfGHjuUUBewGo1SFy9FYo4=,tag:sLYq27NhTP9e9ITuoMRawA==,type:str]
-      name: ENC[AES256_GCM,data:nCIIVhjQPtFMbfM=,iv:AoHtSjtMs3SdqYIEabpxcnquJB+Bf10XlgSxUbHS10Y=,tag:iAHVWo/fLgGRMAECCzPGHw==,type:str]
+    - group: ENC[AES256_GCM,data:oLjhxYVlKopwEw540uxwDXiSkJBTVo2HRw==,iv:H7e8rsek39HfvNKlig1+Om3kWYlPKeKJsbLQmhUO/uM=,tag:yL4G7k4E0Po9jb8tILJd2g==,type:str]
+      kind: ENC[AES256_GCM,data:sHqFwBa9sw==,iv:gRWPcEM/68KqNSGMEnlvptzydoCuCSnXXYmcg6bJXfQ=,tag:xHk/K3Z8SHrjGKB0aGdKzQ==,type:str]
+      name: ENC[AES256_GCM,data:GG7+y2Hcr4Bw57Zz/E6q3pY=,iv:SoZi1Oi9o4SslmFtxgLXHbDz/7ONDgXZWVOp61xTvNY=,tag:4guewQ03fxU9o+z2zvqO/A==,type:str]
   oidc:
     provider:
-      issuer: ENC[AES256_GCM,data:F1Pq7TEBdhOGQ/Kf4pimpA0Vuf198DHT7hKf,iv:GRGkDXQZc93eMv+46ReON/6nebw345B/gHutVw5G/qw=,tag:I2axRh6Ohs2XqLph7yJgRA==,type:str]
-      authorizationEndpoint: ENC[AES256_GCM,data:BOw3GL3l8KVbN+8Z4R7Vbo/5+vPQml5rjNcC5ilB58wfJHwVCEpRW776d72EUHgjXGgEfFbmCiIaEy8HXXX3iWmN,iv:n9B9zK/aDFiEQ6qqRxwdIj5vXkrGsSIALWBak5IZhxo=,tag:dklrQFa8zqJbN8ROwlxPyA==,type:str]
-    clientID: ENC[AES256_GCM,data:1offTc2kIY6MS4NEUax6WY7u2PWud37ZaKRtVPK6PXBJ/VyxJqz7M1q3W+wjLiF4tZkxnW9RFsAflqQ0xxlRrkVIa+g353ot,iv:1FunguJN4gDhPXvCjqFhy71CUCr8QLgw5JSzyaXxGQI=,tag:onQRG6BXuWEtwnCUX5YX5g==,type:str]
+      issuer: ENC[AES256_GCM,data:5Bq2ijva17M8zKazGGXVuvkA1A2019PQm/cO,iv:ca3UQQrLmiz21D4gHlTknsclDVePoLnDAsnRq98fajY=,tag:zaa8zq3QvqOIuRA0vkz5/A==,type:str]
+      authorizationEndpoint: ENC[AES256_GCM,data:bkXW7pOiUa8cex+PhAsu2fcoSWO0zrOuG7XRVbAxDAGmOPJ+qQ7e/f70u1kwEZocshtdBaoQzRpZqzzEB8qQq0YU,iv:9rCCkg5+mxex37S/jfYNzfG78Ukg6fcZGDf4vcOCthc=,tag:0kK1uKlLBPDarxvA6QMhGw==,type:str]
+    clientID: ENC[AES256_GCM,data:z9SurScgpZayuj4V199Qy+hqJlkg+KD/BtPFRDfS/RQrIwQr6OHNeMpp3plcHEhurRD4sY2ZdZApAmGFT/1pGCNYQmvYB4Jx,iv:TzI4os5oncMsQ4JJXlOI46Se0OF7C/U9W5AYN7g4Zj8=,tag:7OjMx6L2W6NjSF5CZay23Q==,type:str]
     clientSecret:
-      name: ENC[AES256_GCM,data:XquF25GtFXcnyYuCu1qX5UkrTWcspBr/cQE=,iv:+CCm9wvnb2bEsVN7rgRxl8H6A9rPyjLl0uACyygQFCQ=,tag:Voju9nmW/AsA6Yukpm/BYQ==,type:str]
-      namespace: ENC[AES256_GCM,data:AiAV8Qz5Og==,iv:H921a3GGEB2N4StnqnaLtgN9WquzYK9qF2Im4j9TNVg=,tag:6Z/QIFOAy6D9VAL62FmnNA==,type:str]
-    redirectURL: ENC[AES256_GCM,data:iatxKOnQy3Z5T/FXNmNy4zInjDMI4kqqxB+xxL1GccsktMZ5mVAKQD6bX8vTKg==,iv:SuEpgNyAW+LKUSmf2Oz1ZfIUPh2XgxQlZ7iKOtYuCO8=,tag:daXQFXXz06AzCA4sNJOT1A==,type:str]
-    logoutPath: ENC[AES256_GCM,data:M8g4yu4r+Q==,iv:1rQQOLtxCy5wi7p+z37ELeJvR2jO90rdbyCzN6uNg2A=,tag:Y3b+ywoGvUtBBSIZ74niHw==,type:str]
-    cookieDomain: ENC[AES256_GCM,data:z2jHxGbyjMSeis74g8w4tw==,iv:CpvRktySUXNMCFV43oWA/Ys3N68TQqyt1O/dLRVDzBM=,tag:+E1lM/VM4OH9nJicNVSeFw==,type:str]
+      name: ENC[AES256_GCM,data:49F8uyOglo08wGzOjblfz7oVUZcns/hO+7k=,iv:mrb7BTQHve27nn/NPmceU119fG2FOKARUuxRTs4nylk=,tag:7cVc2b6x6nvBvU6zwSkppw==,type:str]
+      namespace: ENC[AES256_GCM,data:OYjOVe6RpA==,iv:hqM/SBLlZ+zUs0sW587gCQaKEX7zdpMzA0+GBmOE9VU=,tag:4R95Qdiux3SgOhX2vCvkcg==,type:str]
+    redirectURL: ENC[AES256_GCM,data:jalqWyUwAlegeuAQtcKAABH1Ze9z9VMc2jCePcHB5TPry0ZTX9c025wS5Y1XYg==,iv:GiY47eNTm1yvYJdVe9S4c4pzsMpoh93f/a0wjlyeMmA=,tag:SsZG71w3FAxjBnfPWh17ag==,type:str]
+    logoutPath: ENC[AES256_GCM,data:QLwzhS3c2g==,iv:Qfk1Oz26Z1lZuZIGoT5kGV/3zgFmG9t7HHhEOIWuscU=,tag:q1GxqIq/Y/c6sbwfF/SvhQ==,type:str]
+    cookieDomain: ENC[AES256_GCM,data:ooqY6mPn/9KK1CLSe0uE3g==,iv:T/9+DRbSSmT0y9iPtTZFTVV/bSoTLqXs7+I4I+l2+Xo=,tag:sij0jpouV3L70+UW+xaovQ==,type:str]
     cookieNames:
-      accessToken: ENC[AES256_GCM,data:lccX7LqfjHiWdb8=,iv:FzkKZlc2N0qSNMgiPf1DTL9xHH5djqBXTNnhQ+M1mrk=,tag:lbrdGB+NPuFIF6CXTqdvEw==,type:str]
-      idToken: ENC[AES256_GCM,data:37xhcK184g==,iv:8RvyhszjT6b3X8wteeJPruq4dzenYhOQjxiB0wamZrg=,tag:qgmCuySQYyHkDmsFUiXN5w==,type:str]
+      accessToken: ENC[AES256_GCM,data:agtwTgyL/M/R5Kg=,iv:hedDC/6ln13Iv6oXtCAlJuytXOBfpILvDbsLdFbGRfQ=,tag:W5nqQkjNsiTw/ZCEXH4Lxw==,type:str]
+      idToken: ENC[AES256_GCM,data:2sbjFAS0Cg==,iv:z8EHmfGfduSJo/NcdGLiyz4jSpoExTW3XsYNUfMRjm0=,tag:Uo97WZTqG+OTFp+rAdjrxw==,type:str]
     scopes:
-      - ENC[AES256_GCM,data:CRzAi9nE,iv:b7ZwtT134OSF7xArUInZVi+wMnQ5g5aXXyWZu3PSS+A=,tag:GMwCVU3+hcF8np0XsOSoPQ==,type:str]
-      - ENC[AES256_GCM,data:8Z0ciKs=,iv:4sc1VoDHCrnAHZtcD5u2Hy1v2C2euHZys3dImVOJJCE=,tag:2zQh3YYq5f7C5/0F8ksBlA==,type:str]
-      - ENC[AES256_GCM,data:JDMnzI7bug==,iv:C2AmcwsnpAORlF1MMXEDEnEW4DDJz0lZnKW/koD+E6c=,tag:KtyzRVZ2qxdXL2MUNgXs5A==,type:str]
+      - ENC[AES256_GCM,data:mbqVkbHz,iv:UhDSwkUZR6lB2L9/xIRL3wOa3lADL8CtJf+AM5MMk7w=,tag:cYc/DqSWOu3vu1dB1A2ngA==,type:str]
+      - ENC[AES256_GCM,data:vcoAXc4=,iv:Rxb/tOyd9u53y9mTPV9LaEMpXPN6hZmiWCVRZ2zdSgw=,tag:WIHS3SysQY87Be6DP/31Nw==,type:str]
+      - ENC[AES256_GCM,data:zGxjenIOnA==,iv:61FS3ycFj+Y12QiYGsvhPxCxmT72Yf2lXAd6praMiBw=,tag:UNxWbE5XqGxrg2eNB1ix9g==,type:str]
   jwt:
     providers:
-      - name: ENC[AES256_GCM,data:BPxpXSSe,iv:uOOMOoQkP5N9sEUlR2VaSHhbPArfYCc6gWVeBXNLcbE=,tag:KCyWu4mmEzSPCb9bqPaZew==,type:str]
-        issuer: ENC[AES256_GCM,data:Z5HrywFxIWnggcHtTUX5jfTRrWTlEkOxfKtz,iv:goPKCAAtladY9amro+5lX/Mw2CBVHVc38cwfjQC9I18=,tag:3tTmTOCQytGjac8sNNYoiA==,type:str]
+      - name: ENC[AES256_GCM,data:kWGYa63J,iv:BKKz2G0IeLZG+7Qjm0OcGtfYP5o4sVb+gKwVswoSSQI=,tag:lV/JSGuuuJvjbsrhNteDpA==,type:str]
+        issuer: ENC[AES256_GCM,data:M6TC/nT6le5oneZhYUzGVTNw4jQX++5ccfO0,iv:v42TsU8j0f/bOiESq8rK9XrTbwGeaN30sfIPPyXTZ2I=,tag:6rlaiOefPe8iC6PX2c0pcA==,type:str]
         remoteJWKS:
-          uri: ENC[AES256_GCM,data:XNeWwjsC6GDQ38Tqj7uxwWkwZGyIIAp/6kEVWeoBM0o+ATp4LeUMTYg7,iv:ko2kOnv9bC5uSyrvc5GVrg101g9b+qcDe/BbhKk/B90=,tag:5lnJJnZf4ZDjGRIbUKaGqw==,type:str]
+          uri: ENC[AES256_GCM,data:GvaX1H7C2s4VqFvqXt+2Z7oWcTAnq/vYSnnwXCWoM0d0JrxDY8k5kTQ5,iv:IKxBCmqH9K6VkzXAU2gQV71nxtmh0RDJSAP1TyOTVZM=,tag:2eFSCSvjFehK0o0j/9Mxwg==,type:str]
         extractFrom:
           cookies:
-            - ENC[AES256_GCM,data:z1KwFxQj6w==,iv:A1ZF1647VBzk1xM4yLWdbuEwD+aKmJnqDxG5Jg9w5lg=,tag:94w+2N28z8HrdNqd/xm89Q==,type:str]
+            - ENC[AES256_GCM,data:4nZ1IVhl+g==,iv:VwAm5lab9o8HoH19TGFtGpp7PwvG77vwTEDMy5XVTgk=,tag:nCEobHtLjnJFLSgiIRLiKw==,type:str]
           params:
-            - ENC[AES256_GCM,data:wqCGeXeExa3f+HEn,iv:PW7xuSO5vya878gij7yHTgYLz7FaEkdFszmrJ6p+0VE=,tag:Pc8s2kuLwpXNmspkEhXBbA==,type:str]
+            - ENC[AES256_GCM,data:UIIB2MhRKMvnvwRv,iv:1BV6p7WW1uJeFe0L7dNP81WWRVJqHuxGnuRfViKBKr8=,tag:RsFD5VRQQnUkg0b7wvnnLA==,type:str]
   authorization:
-    defaultAction: ENC[AES256_GCM,data:EDzrgw==,iv:TdGIa8iYxjEHzS/HmGmPn+7KWE96bUknCeVsjnh9afw=,tag:Ax9Nt4eoDA+iRSX/gLjZhw==,type:str]
+    defaultAction: ENC[AES256_GCM,data:LzZOmg==,iv:MvzrWn11edTpbnSXHQhD26voqLoagUS4d0ef5TF1jDU=,tag:IYd0jyCBvvbhhNs6ebMstA==,type:str]
     rules:
-      - name: ENC[AES256_GCM,data:KOqwbZSz2p9nK5I/1xvN,iv:RsZncGfA0aqW/OHpw9wUYIofA/XiSfpPkWOY26jdamg=,tag:ftvUqYhDMsthKOD6i3lgzg==,type:str]
-        action: ENC[AES256_GCM,data:xx9oFno=,iv:rgsH3+FvrThDMH980toGyLpA4Rr8w5ylZRu8bCsb8Jc=,tag:ONLSiiSO/gpRDqtqBb5wKA==,type:str]
+      - name: ENC[AES256_GCM,data:873tn0gLc1bGiDyGTkL3,iv:dkTESaN7qTPtdEX9T6PZgKkBfEzGYULUnWCE1sthz+Q=,tag:4ZOHj5O49+DbMYJ7+j5HrQ==,type:str]
+        action: ENC[AES256_GCM,data:sWauDUI=,iv:IZk1t38l6x36eEfUllZJFK0gAB3ttsb64WpM7nzgJAc=,tag:ikX3yXM5WZYhbmOMIDceuw==,type:str]
         principal:
           jwt:
-            provider: ENC[AES256_GCM,data:oX4xfeMC,iv:NfJBBUWRqQByLpkqyB6gUB8eDCtk82KjnTFsYabwqug=,tag:HIrWPJw7N+woAONu0tNqqQ==,type:str]
+            provider: ENC[AES256_GCM,data:1UZ+nkJ0,iv:gqIyCz3SfgGsR2vVWpyZ97Gc3YmZU+zoCfuFqTxqkWI=,tag:yuV+E/U4ED14HOrL33EUAg==,type:str]
             claims:
-              - name: ENC[AES256_GCM,data:HkBjw/c=,iv:A5GgUaCPS7wTeZ/tpVeLqZ1u1M3Ja/PXa3A6UWvJY1A=,tag:11IhG+0rlRnyRs9B6rUsMQ==,type:str]
+              - name: ENC[AES256_GCM,data:bcYWyAY=,iv:iCHvMMfugHKJBA4VY0o2BWNQHzmwlS6cVVo+VPRXQQw=,tag:NJttYLby+1n7aC+tdaKEdw==,type:str]
                 values:
-                  - ENC[AES256_GCM,data:Lw6k6vcD5Jef/CDf2q/FEw==,iv:42fd5OVjg0hofzvWSa+w0Z5tZDtFuGVw4UGzRQYkMlU=,tag:I3Sj7XD4jkjwYTr+6sL78A==,type:str]
+                  - ENC[AES256_GCM,data:3VA2C3CgvPhaIKbQUxgJDA==,iv:4BJxghwpI258EplHG7S5Bel9pz9un4UehbrJonY6+lw=,tag:FNaUBQTsAv5t7EcZ9FONMQ==,type:str]
 sops:
   age:
     - recipient: age1d7ltdyge970mha3gqyenf9mrn8ezg60nexy99vzndvl592q2zcxqkytdwd
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4MkQvam9YVHpZQkNidDdh
-        QVFvSFk2ZTMvSlNsM2NCbFRkRGJiWG9IZkRrClVROVBHVXB2N1o3dnFFR0dvU1lV
-        bUtaMCs0RHhLbEF0VGFrVkptZUNmSWcKLS0tIE1KZUJYOG5UQi9wSjNBYXZzaStw
-        S0tjRWtwL0JRbkNXbGd0YjJ5czc4RDgKjf0zIB9VvydDP2tZgwwxUYdIvulAOLXJ
-        5epfGc+DF4XvZQtl6Xn4bGZNpqMFQTE90vYIfN1XywQnXvSBRv5t4w==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEdFFDc1JhUmFwa0VOdTRt
+        cEc3enNuV2NCd09QMzFVNUZhSFk1N090cFM4CjhxbnYvWVh6czU5cnpibU9YUEFX
+        U3ZkTXYxRmdVNlZveWhwanRvSEQ5ancKLS0tIHNUMTR3YjNmZU9JY3VOOGU4Mndv
+        ZjIwR1BKcmVqeHdLWHJoMTRSNEw5TDgKgDJuI2KnAqHrJE1ZOcA+67oSZ3RikOL4
+        J7I4KhE8KRc2pMj8LnFD3+xqTUvawiLpQcGQ/lizZ/6BuBlFP6g35Q==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-02-25T04:33:13Z"
-  mac: ENC[AES256_GCM,data:/briarTVyLWK2cvfOrlHjAZX31vo9cQ61vPSSiVBwcnbTCr+x3WT6NgsGv8XIs3ol/khKI1qJubpzUrRYot+BV4t2ePeM9PFr4gInIJaGNIt1bB2L4nmFKIK4nbyX8wgrzYfBjdTYBa32QjfxYZ8/x+EdVvZxT4PmfRxtiHlj3k=,iv:jPFGB/usk2r7/JTjamR4O52jLjocd4huVJ5v+mE1ep0=,tag:+BkoEQkZWtIBGfDaAzcFHA==,type:str]
+  lastmodified: "2026-03-12T04:49:00Z"
+  mac: ENC[AES256_GCM,data:W9afEg6YaIyoo05K0Lwljq3Ar3oltxqpMFpv6TMR/Dh67g2+kSxMo4w3MZa4f3uWYCbJKhoyEX4BKox2Z6pRIvQHTkSe6r+9Aag46H2B5OKbt12aPO0HfPi6FLXeQlRsy7c2REw6n1N934ePVEedk95cTnD2jn6P+GU2Qac1RPw=,iv:Lh1TNct5MNh8slHCjW3oUP8ALd8dQxN+kyqAyZpBPlY=,tag:9ZlZuskijb1laAZW3Ewpiw==,type:str]
   encrypted_regex: ^(spec)$
   mac_only_encrypted: true
-  version: 3.11.0
+  version: 3.12.1
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: envoy-oauth-users-policy
+  namespace: network
+spec:
+  targetRefs:
+    - group: ENC[AES256_GCM,data:X1c8MGWB0ooBmsKtyDTMqRqhXTJaPcmXdg==,iv:BNalln77VdN7bDNTnDtG8rD7ebafwUvlCQ6OAVpEfRU=,tag:NzxTTA7xMx3M67EJn+hbtw==,type:str]
+      kind: ENC[AES256_GCM,data:fZmyLJITYw==,iv:S2p0Ndi394k0BXFXoi3C9tNhi6zN1GcZdI2SmE6dQfA=,tag:UkLxQMQZDh5l0t4XRsgeAQ==,type:str]
+      name: ENC[AES256_GCM,data:M0Z5kuw0rn8SX0xt3bGEKOk=,iv:9+IBiA6R2xmHjvxVge2c11NtrT+aiYD1minjM57vh3E=,tag:j5NZdThx0t0En0FWBPJv2Q==,type:str]
+  oidc:
+    provider:
+      issuer: ENC[AES256_GCM,data:HY4va89EQhz0xkFDqcDs8rur/FcCbdbTrrex,iv:N1ANjBOwePOQR6FxVWOW4mSZmNuw2kBD8xDj+3g7eiM=,tag:a5BrchlgrNlOBp1KVR+6uQ==,type:str]
+      authorizationEndpoint: ENC[AES256_GCM,data:rqoSCgWroIMkpnoISWt04vNF/VuCA6JA9RitR+2XZs1Y6n5LM7L0cxmYbtfiG5EeEGBpw+JtBrrWm8ZL/Xlz4Nr7,iv:AWuGgEDU5rvI0tm88U12t25Glx9o0C+xwQ+SxSWBO2s=,tag:KgSRZLjOAqK+DSkpmFl2aw==,type:str]
+    clientID: ENC[AES256_GCM,data:U14q5ttWiB7RyoezR0vqr/dlrg3tTMQDvaSV3Jhc8ZCrhPmN0J0Tad5XpwfTbB6/ck2BRuJWwKKXObTegUqU0xOm8PuFmV2R,iv:URX7+cDv1X4OA0iQHXlghG4GiUWvW4mcOH/TQ8vKEyg=,tag:KZwb6+hhwjxQx8iwv7qc4A==,type:str]
+    clientSecret:
+      name: ENC[AES256_GCM,data:IrmSUNOm2u+aiIzm8ZWAYm+wy2iUCoQm+Zo=,iv:Gk7BsQSFx2wud79E83z3dMfNtE7u+pV+zxjQd2p9tEg=,tag:bv/bzaB4zJO1G0FgajQzZg==,type:str]
+      namespace: ENC[AES256_GCM,data:O3047/RQRg==,iv:Byph8ETsmn8dKK9BoUPfpbp74PN1SIEUTPxlw1fvfH4=,tag:oOEFsOr35Nb0LdE71e5XZg==,type:str]
+    redirectURL: ENC[AES256_GCM,data:eiKdnqx/lSh/e0WMcPzK6HwiOxDjLETxe3DAeCdrKaw5ZJuQL1reGfbVGbGHLtpz4bUz6g==,iv:cDazexTkgPxHq0Mjfj/S4TybqHRoPghq+tOXHSibMUk=,tag:ED0SwNrA0/OS7sFeVFFadQ==,type:str]
+    logoutPath: ENC[AES256_GCM,data:43S/ecUjPQ==,iv:AuciVK+8HgbWs1svFCn5AvwFXMmBOxSoOm8EsYto5Gg=,tag:7h4woUj/XTux/n8vfrykVg==,type:str]
+    cookieDomain: ENC[AES256_GCM,data:McpS0H3HQuVIckEipn/Sjg==,iv:ji73imcXtAZ8uKbPc01ifumIQO6T74FzIXo/HpIXv2w=,tag:CQ/L3GA2xkmy3lN4WnNLNQ==,type:str]
+    cookieNames:
+      accessToken: ENC[AES256_GCM,data:XVdqdcGZoqlR3+o=,iv:LtLCrCk6SzQezUughTSqCO+Ndx+xAmh7z0Qa3EE+IO4=,tag:7Z7Cutj6YLwLNcTpyqmdcw==,type:str]
+      idToken: ENC[AES256_GCM,data:gcNvEylj7A==,iv:/LdSEhyOaH2UzrU/K5nTaEP8Goi6pdK9C9w+6+yqLAs=,tag:lrT10551yHkM6mrBzoTpgA==,type:str]
+    scopes:
+      - ENC[AES256_GCM,data:P8CQ3DXu,iv:qM6R5zpTqsNJBMRHKyipIe+NPAjMm84M+/FE4fN27fQ=,tag:uGGbkpu7O2UG6lZHZWxxkQ==,type:str]
+      - ENC[AES256_GCM,data:zwmYiZg=,iv:49nuIapCaUDsGIiqWYzggT+9uN4Em02JfwSyeZR7g7Q=,tag:/OqqNBbqtJP6wVSsPJmuRw==,type:str]
+      - ENC[AES256_GCM,data:uUOJ2kBi7g==,iv:ijGqDTgSv38Mqd2JIuf4borlFvVcAe2HQs/UbSs7MSw=,tag:kmERBAT8RKBENt92C3EzBw==,type:str]
+  jwt:
+    providers:
+      - name: ENC[AES256_GCM,data:LkULw5YR,iv:iOnrfUADbbGCmvW8D++ZBwQXJFllRqkH/TxfANsmW5Q=,tag:i13MALZSnEiV8hJnsJbmaA==,type:str]
+        issuer: ENC[AES256_GCM,data:DA0RSmxoZqfnrl4nnr/4xniGTCg3f0opejSG,iv:ruZnCSTXohIc3jF/66O1FYHhYVtujFYnIKKRhckF4OU=,tag:pUQbXvxsA5XAOcbVT/nijQ==,type:str]
+        remoteJWKS:
+          uri: ENC[AES256_GCM,data:8SYiu3qwiQTux6jHye7O+9U6bWkXjZaHqC3R//Da6DhpnIWyi9/KA1gs,iv:hRYmTGWDzeYfpc16IZdnixr+lYx7phH0TJymQZIJqDc=,tag:hXwL7JZFeYjMwkGVUblUaA==,type:str]
+        extractFrom:
+          cookies:
+            - ENC[AES256_GCM,data:HvmE/Te5eg==,iv:xYwmlWsO0caAZGXS1b6eVlwLyDnBbdxBsZk6KdAoits=,tag:A+6XbXG7eu70CVT6o3nuuQ==,type:str]
+          params:
+            - ENC[AES256_GCM,data:uX36x4DNqh/qnhtN,iv:onO9yRrf2ZJLTkAO5C1VvjPIwI11shuYw5FLK0Q2Pqg=,tag:y5A61mB5Q1xO2jX7pv6xYA==,type:str]
+  authorization:
+    defaultAction: ENC[AES256_GCM,data:MKsUnA==,iv:Eez9I2Cko/BFUiG3X9XFna3QRwr4DAN4HSMCZGKZUlI=,tag:nOX5YbJSFBo4DG7QZwQLyA==,type:str]
+    rules:
+      - name: ENC[AES256_GCM,data:Iu0RZO/ljUFGka4=,iv:BajwR5Ea8/tx1WkDdNBI7ST5rMQt+D043iImMIEy2sE=,tag:lHfXnWByMwSTWacD3MFf/A==,type:str]
+        action: ENC[AES256_GCM,data:SNhIUec=,iv:4A4cPHR45IknFJzbcikOniNa9sgdx70Dld/hI4paOI4=,tag:VNoNT8FfGt3NE/iNAgyHzw==,type:str]
+        principal:
+          jwt:
+            provider: ENC[AES256_GCM,data:7ducz3af,iv:NcEI0/OujXzVC2z8OU28yN0jpx1i7w+smrSWU8nLO50=,tag:E0l8LNREWCpPEnGwi0/iNw==,type:str]
+            claims:
+              - name: ENC[AES256_GCM,data:ASSYR/s=,iv:u6jW4RT9JvW0U6t0ss37GhWIp3ZDJ0MSVY8Lgj5mAIM=,tag:qtXY4uGMKxJriyi0048/yA==,type:str]
+                values:
+                  - ENC[AES256_GCM,data:TWkm9BcoP9tADsKRx06Stg==,iv:yM0kB+R3lcaPDl2fRzhQFNhliJnrXfjQpEIQk37ONn0=,tag:jFjjqy6xQP3r/ZlNogsoeA==,type:str]
+sops:
+  age:
+    - recipient: age1d7ltdyge970mha3gqyenf9mrn8ezg60nexy99vzndvl592q2zcxqkytdwd
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEdFFDc1JhUmFwa0VOdTRt
+        cEc3enNuV2NCd09QMzFVNUZhSFk1N090cFM4CjhxbnYvWVh6czU5cnpibU9YUEFX
+        U3ZkTXYxRmdVNlZveWhwanRvSEQ5ancKLS0tIHNUMTR3YjNmZU9JY3VOOGU4Mndv
+        ZjIwR1BKcmVqeHdLWHJoMTRSNEw5TDgKgDJuI2KnAqHrJE1ZOcA+67oSZ3RikOL4
+        J7I4KhE8KRc2pMj8LnFD3+xqTUvawiLpQcGQ/lizZ/6BuBlFP6g35Q==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-03-12T04:49:00Z"
+  mac: ENC[AES256_GCM,data:W9afEg6YaIyoo05K0Lwljq3Ar3oltxqpMFpv6TMR/Dh67g2+kSxMo4w3MZa4f3uWYCbJKhoyEX4BKox2Z6pRIvQHTkSe6r+9Aag46H2B5OKbt12aPO0HfPi6FLXeQlRsy7c2REw6n1N934ePVEedk95cTnD2jn6P+GU2Qac1RPw=,iv:Lh1TNct5MNh8slHCjW3oUP8ALd8dQxN+kyqAyZpBPlY=,tag:9ZlZuskijb1laAZW3Ewpiw==,type:str]
+  encrypted_regex: ^(spec)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/observability/headlamp/app/httproute.yaml
+++ b/kubernetes/apps/observability/headlamp/app/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   hostnames: ["headlamp.${SECRET_DOMAIN}"]
   parentRefs:
-    - name: envoy-oauth
+    - name: envoy-oauth-admin
       namespace: network
       sectionName: https
   rules:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   hostnames: ["grafana.${SECRET_DOMAIN}"]
   parentRefs:
-    - name: envoy-oauth-admin
+    - name: envoy-oauth-users
       namespace: network
       sectionName: https
   rules:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   hostnames: ["grafana.${SECRET_DOMAIN}"]
   parentRefs:
-    - name: envoy-oauth
+    - name: envoy-oauth-admin
       namespace: network
       sectionName: https
   rules:


### PR DESCRIPTION
## Summary
- rename admin gateway to `envoy-oauth-admin`
- add users gateway `envoy-oauth-users`
- keep external policies in one file (admin + users docs) and update allowlists
- route Headlamp to admin gateway and Grafana to users gateway
- update Cloudflare tunnel origin mappings and OIDC runbooks/checklists

## Validation
- `task lint` (passes)
- `flux-local test` via Docker host-path workaround (41 passed)
- `task dev:start` + `task dev:sync` applied branch
- verified live Gateways/SecurityPolicies and route parents

## Notes
- This branch is currently deployed for testing via `task dev:start`.
