### PR TITLE
🧹 Simplify dev worktree create to one arg

### DIFF
--- a/.taskfiles/dev/Taskfile.yaml
+++ b/.taskfiles/dev/Taskfile.yaml
@@ -13,10 +13,10 @@ tasks:
   worktree:create:
     desc: Create a feature worktree under ./worktrees and link required local files
     requires:
-      vars: [NAME, BRANCH]
+      vars: [NAME]
     cmds:
       - mkdir -p {{.ROOT_DIR}}/worktrees
-      - git worktree add {{.ROOT_DIR}}/worktrees/{{.NAME}} -b {{.BRANCH}}
+      - git worktree add {{.ROOT_DIR}}/worktrees/{{.NAME}} -b {{.NAME}}
       - ln -snf {{.ROOT_DIR}}/age.key {{.ROOT_DIR}}/worktrees/{{.NAME}}/age.key
       - ln -snf {{.ROOT_DIR}}/kubeconfig {{.ROOT_DIR}}/worktrees/{{.NAME}}/kubeconfig
     preconditions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Always work in a git worktree to keep the main checkout on `main` and isolate fe
 
 ```bash
 # Create a worktree for the feature branch under ./worktrees/
-task dev:worktree:create NAME=home-ops-my-change BRANCH=feature/my-change
+task dev:worktree:create NAME=home-ops-my-change
 cd worktrees/home-ops-my-change
 
 # edit kubernetes/ manifests

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -96,20 +96,20 @@ ______________________________________________________________________
 Defined in `.taskfiles/dev/Taskfile.yaml`. Enables testing changes against the live cluster
 **without pushing to `main`** by temporarily redirecting Flux to watch the current git branch.
 
-| Task                                                   | Description                                                                                                                                              |
-| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `task dev:validate`                                    | Run `flux-local test` locally via Docker — validates all Helm renders and Kustomization builds with no cluster required                                  |
-| `task dev:worktree:create NAME=<name> BRANCH=<branch>` | Create a feature worktree under `./worktrees/` and symlink `age.key`/`kubeconfig` into it                                                                |
-| `task dev:worktree:remove NAME=<name>`                 | Remove a feature worktree from `./worktrees/`                                                                                                            |
-| `task dev:start`                                       | Push current branch, suspend the `flux-instance` HelmRelease, patch the `flux-system` GitRepository to watch the current branch, and trigger a reconcile |
-| `task dev:sync`                                        | Push new commits on the current branch and trigger Flux to reconcile them                                                                                |
-| `task dev:stop`                                        | Restore the GitRepository to `refs/heads/main`, resume the `flux-instance` HelmRelease, and trigger a reconcile                                          |
+| Task                                   | Description                                                                                                                                              |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `task dev:validate`                    | Run `flux-local test` locally via Docker — validates all Helm renders and Kustomization builds with no cluster required                                  |
+| `task dev:worktree:create NAME=<name>` | Create a feature worktree under `./worktrees/` and symlink `age.key`/`kubeconfig` into it. The git branch name is the same as `NAME`                     |
+| `task dev:worktree:remove NAME=<name>` | Remove a feature worktree from `./worktrees/`                                                                                                            |
+| `task dev:start`                       | Push current branch, suspend the `flux-instance` HelmRelease, patch the `flux-system` GitRepository to watch the current branch, and trigger a reconcile |
+| `task dev:sync`                        | Push new commits on the current branch and trigger Flux to reconcile them                                                                                |
+| `task dev:stop`                        | Restore the GitRepository to `refs/heads/main`, resume the `flux-instance` HelmRelease, and trigger a reconcile                                          |
 
 **Typical workflow:**
 
 ```bash
 # Create a worktree to isolate the feature branch under ./worktrees/
-task dev:worktree:create NAME=home-ops-my-change BRANCH=feature/my-change
+task dev:worktree:create NAME=home-ops-my-change
 cd worktrees/home-ops-my-change
 
 # edit kubernetes/ manifests ...


### PR DESCRIPTION
## Summary
- simplify task dev:worktree:create to require only NAME
- make branch name match NAME automatically
- update examples/docs in AGENTS.md and docs/TASKS.md

## Validation
- task lint