### PR TITLE
🤖 Fix Renovate kustomize manager file pattern

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -23,7 +23,7 @@
     managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"],
   },
   kustomize: {
-    managerFilePatterns: ["/^kustomization\\.ya?ml(?:\\.j2)?$/"],
+    managerFilePatterns: ["/(^|/)kustomization\\.ya?ml(?:\\.j2)?$/"],
   },
   packageRules: [
     {


### PR DESCRIPTION
Summary: update Renovate kustomize manager file pattern so nested kustomization files are matched. This ensures updates under kubernetes apps are tracked. Validation: task lint and task dev:validate.