### PR TITLE
🔧 Fix ArgoCD CMP script resolution and OIDC bootstrap

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -34,7 +34,9 @@ tasks:
         sh: "sops -d --input-type yaml --output-type yaml {{.ROOT_DIR}}/kubernetes/components/sops/cluster-secrets.sops.yaml | yq eval -r '.stringData.SECRET_DOMAIN' -"
       ARGOCD_RBAC_ADMINS:
         sh: "sops -d --input-type yaml --output-type yaml {{.ROOT_DIR}}/bootstrap/argocd-oidc-secret.sops.yaml | yq eval -r '.stringData.argocdRbacAdmins' -"
-    cmd: ARGOCD_TARGET_REVISION=refs/heads/{{.BRANCH}} ARGOCD_SECRET_DOMAIN={{.SECRET_DOMAIN}} ARGOCD_RBAC_ADMINS='{{.ARGOCD_RBAC_ADMINS}}' helmfile --file {{.BOOTSTRAP_DIR}}/helmfile.d/01-apps.yaml --selector name=argocd sync --hide-notes
+      ARGOCD_OIDC_CLIENT_ID:
+        sh: "sops -d --input-type yaml --output-type yaml {{.ROOT_DIR}}/bootstrap/argocd-oidc-secret.sops.yaml | yq eval -r '.stringData.argocdOidcClientId' -"
+    cmd: ARGOCD_TARGET_REVISION=refs/heads/{{.BRANCH}} ARGOCD_SECRET_DOMAIN={{.SECRET_DOMAIN}} ARGOCD_RBAC_ADMINS='{{.ARGOCD_RBAC_ADMINS}}' ARGOCD_OIDC_CLIENT_ID='{{.ARGOCD_OIDC_CLIENT_ID}}' helmfile --file {{.BOOTSTRAP_DIR}}/helmfile.d/01-apps.yaml --selector name=argocd sync --hide-notes
     preconditions:
       - test -f {{.KUBECONFIG}}
       - test -f {{.BOOTSTRAP_DIR}}/helmfile.d/01-apps.yaml

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -32,7 +32,9 @@ tasks:
         sh: git branch --show-current
       SECRET_DOMAIN:
         sh: "sops -d --input-type yaml --output-type yaml {{.ROOT_DIR}}/kubernetes/components/sops/cluster-secrets.sops.yaml | yq eval -r '.stringData.SECRET_DOMAIN' -"
-    cmd: ARGOCD_TARGET_REVISION=refs/heads/{{.BRANCH}} ARGOCD_SECRET_DOMAIN={{.SECRET_DOMAIN}} helmfile --file {{.BOOTSTRAP_DIR}}/helmfile.d/01-apps.yaml --selector name=argocd sync --hide-notes
+      ARGOCD_RBAC_ADMINS:
+        sh: "sops -d --input-type yaml --output-type yaml {{.ROOT_DIR}}/bootstrap/argocd-oidc-secret.sops.yaml | yq eval -r '.stringData.argocdRbacAdmins' -"
+    cmd: ARGOCD_TARGET_REVISION=refs/heads/{{.BRANCH}} ARGOCD_SECRET_DOMAIN={{.SECRET_DOMAIN}} ARGOCD_RBAC_ADMINS='{{.ARGOCD_RBAC_ADMINS}}' helmfile --file {{.BOOTSTRAP_DIR}}/helmfile.d/01-apps.yaml --selector name=argocd sync --hide-notes
     preconditions:
       - test -f {{.KUBECONFIG}}
       - test -f {{.BOOTSTRAP_DIR}}/helmfile.d/01-apps.yaml

--- a/bootstrap/argocd-oidc-secret.sops.yaml
+++ b/bootstrap/argocd-oidc-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-secret
+  namespace: argocd
+stringData:
+  oidc.google.clientSecret: ENC[AES256_GCM,data:Lo702q5fWXZ9A0If5N7t9zFEk10L6ZqqfT0PmA3SqpZDcdk=,iv:9uIFf3i75oPmc0sZgWb5Yr3mnuPhCaqv7vaY43raEzo=,tag:/zqfSgzvvoXAM+EDLYj1vw==,type:str]
+sops:
+  age:
+    - recipient: age1d7ltdyge970mha3gqyenf9mrn8ezg60nexy99vzndvl592q2zcxqkytdwd
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqbWlBQlF0YUJhaGFvZ2kw
+        dlUwK2pkZFFUT1djZXlOY08yUzRWb2R5V0FvCklyR2x3QWhNN202STZGeGZaUWtB
+        T0JOMG0wSDUrS3NHd1JKNXJ6MnNBUzQKLS0tIDJTTitXdjYreFJHUnhjeXBuK2xF
+        dXYrQVErTmY1UkxHYVNIb0Z0aCtBM28KyA0o+dxKWyZKFK834tAU9HHgWFYlawIf
+        ZxlwV4r0OGEO77vyiraKH0Z/FekmftBphI+/u0+j6fvBS6Ww7q64Hw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-03-19T04:42:31Z"
+  mac: ENC[AES256_GCM,data:nw60qYtKtyejjnBpLZuSslXMqveRp/MYtHvUSyJMltp+isFvrHfb1HilZcgboDx1vprNKpk0f6Jvu++0r/mTvAtrtaDUTl/7cNPayUBnaDOngLfQW6Zv324Vr4jP/hNguksDm+FEUlxu4e67LxNUL9GRSgrxNvJz4CIWC0Zw1Dg=,iv:DKrgPZ8/RvjkO5vIKMd675DxJAlA+jKTN4zXPs8h5Uk=,tag:0+GLEL2mjPxnqMMmCtpUBw==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.2

--- a/bootstrap/argocd-oidc-secret.sops.yaml
+++ b/bootstrap/argocd-oidc-secret.sops.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argocd
 stringData:
   oidc.google.clientSecret: ENC[AES256_GCM,data:Lo702q5fWXZ9A0If5N7t9zFEk10L6ZqqfT0PmA3SqpZDcdk=,iv:9uIFf3i75oPmc0sZgWb5Yr3mnuPhCaqv7vaY43raEzo=,tag:/zqfSgzvvoXAM+EDLYj1vw==,type:str]
+  argocdRbacAdmins: ENC[AES256_GCM,data:2KCUVHuM7K7HWkpBrndel6kmR0/EdAVlRa88xfiLWZlyTsdH+/NcRhDC/LlKoWhfOr1HGg==,iv:S/5z8j9jB9wamWL3gWrYmddkM3p3CQ1rqwdvqBD0h5Y=,tag:mYkGlICzIbunNoZCmJgy1w==,type:str]
 sops:
   age:
     - recipient: age1d7ltdyge970mha3gqyenf9mrn8ezg60nexy99vzndvl592q2zcxqkytdwd
@@ -16,8 +17,8 @@ sops:
         dXYrQVErTmY1UkxHYVNIb0Z0aCtBM28KyA0o+dxKWyZKFK834tAU9HHgWFYlawIf
         ZxlwV4r0OGEO77vyiraKH0Z/FekmftBphI+/u0+j6fvBS6Ww7q64Hw==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-19T04:42:31Z"
-  mac: ENC[AES256_GCM,data:nw60qYtKtyejjnBpLZuSslXMqveRp/MYtHvUSyJMltp+isFvrHfb1HilZcgboDx1vprNKpk0f6Jvu++0r/mTvAtrtaDUTl/7cNPayUBnaDOngLfQW6Zv324Vr4jP/hNguksDm+FEUlxu4e67LxNUL9GRSgrxNvJz4CIWC0Zw1Dg=,iv:DKrgPZ8/RvjkO5vIKMd675DxJAlA+jKTN4zXPs8h5Uk=,tag:0+GLEL2mjPxnqMMmCtpUBw==,type:str]
+  lastmodified: "2026-03-23T05:03:48Z"
+  mac: ENC[AES256_GCM,data:C8e1pIG8ZtY2GQEmF7k72HMWJYvGKzPVZof1Gqw4PYBaCmVtuw0QmO0m+P5VniEVWoXBkhmRbrf2lc649AsRvdTxGqFU3pfK+nHH8b8MeXu/uY3PasSwawiAHeCtPdmh3b1h0CH7HtZO0r2NCiqZ8L/MbSCAEGLOfa8jN77SXGk=,iv:z6JcLhS2GGK55K8ZJNSpv7Po0l7P+wvM3tFBlGFMA7g=,tag:F8jpNNO9gES8ITQJ7c+Pow==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.2

--- a/bootstrap/argocd-oidc-secret.sops.yaml
+++ b/bootstrap/argocd-oidc-secret.sops.yaml
@@ -6,6 +6,7 @@ metadata:
 stringData:
   oidc.google.clientSecret: ENC[AES256_GCM,data:Lo702q5fWXZ9A0If5N7t9zFEk10L6ZqqfT0PmA3SqpZDcdk=,iv:9uIFf3i75oPmc0sZgWb5Yr3mnuPhCaqv7vaY43raEzo=,tag:/zqfSgzvvoXAM+EDLYj1vw==,type:str]
   argocdRbacAdmins: ENC[AES256_GCM,data:2KCUVHuM7K7HWkpBrndel6kmR0/EdAVlRa88xfiLWZlyTsdH+/NcRhDC/LlKoWhfOr1HGg==,iv:S/5z8j9jB9wamWL3gWrYmddkM3p3CQ1rqwdvqBD0h5Y=,tag:mYkGlICzIbunNoZCmJgy1w==,type:str]
+  argocdOidcClientId: ENC[AES256_GCM,data:sid0uNjXHjrxniO9AbPj/v96UbJNZUDVVlkGtilWQRIj+/+ou5pn3ntFkHicWsyYs/xyXAs+6fNO1St67UMevAycK491pfNd,iv:Bjz+NweiVkl5DFH6YFet8xiukqjWLTobw/E7oN6Xe04=,tag:68to5egf+DjnRhkJ2SbxEw==,type:str]
 sops:
   age:
     - recipient: age1d7ltdyge970mha3gqyenf9mrn8ezg60nexy99vzndvl592q2zcxqkytdwd
@@ -17,8 +18,8 @@ sops:
         dXYrQVErTmY1UkxHYVNIb0Z0aCtBM28KyA0o+dxKWyZKFK834tAU9HHgWFYlawIf
         ZxlwV4r0OGEO77vyiraKH0Z/FekmftBphI+/u0+j6fvBS6Ww7q64Hw==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-03-23T05:03:48Z"
-  mac: ENC[AES256_GCM,data:C8e1pIG8ZtY2GQEmF7k72HMWJYvGKzPVZof1Gqw4PYBaCmVtuw0QmO0m+P5VniEVWoXBkhmRbrf2lc649AsRvdTxGqFU3pfK+nHH8b8MeXu/uY3PasSwawiAHeCtPdmh3b1h0CH7HtZO0r2NCiqZ8L/MbSCAEGLOfa8jN77SXGk=,iv:z6JcLhS2GGK55K8ZJNSpv7Po0l7P+wvM3tFBlGFMA7g=,tag:F8jpNNO9gES8ITQJ7c+Pow==,type:str]
+  lastmodified: "2026-03-23T05:09:53Z"
+  mac: ENC[AES256_GCM,data:YZ9rK0f3iqnsiu2083AClU05rPrPA+iFuc3WcGf9oae8v5lnnpaS2HlqDJ5efVDbAw68ILypbzvhSwrnpxlrOFTFsb8YOWSlfhj1BQk7e5d55gQDgRqfNwMvcfsI3LYndPeLTC6p9tth1OyF+J1K8yorFgmgKvyElh0CPfCn+fg=,iv:W7yEI3zRcO6+aq4aWk//+9FwbER/GDbZgE22uos2nV0=,tag:79YXaJECAHRa6x9YbJu49w==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.2

--- a/bootstrap/helmfile.d/templates/values.yaml.gotmpl
+++ b/bootstrap/helmfile.d/templates/values.yaml.gotmpl
@@ -1,6 +1,7 @@
 {{- if and (eq .Release.Name "argocd") (eq .Release.Namespace "argocd") }}
 {{- $argocdTargetRevision := env "ARGOCD_TARGET_REVISION" | default "refs/heads/main" }}
 {{- $argocdSecretDomain := env "ARGOCD_SECRET_DOMAIN" | default "example.com" }}
+{{- $argocdOIDCClientID := env "ARGOCD_OIDC_CLIENT_ID" | default "706743218818-jp4s5vunfp9ac1euuu4j0sh5t46palg6.apps.googleusercontent.com" }}
 crds:
   install: true
 extraObjects:
@@ -49,6 +50,18 @@ configs:
     url: {{ printf "https://argocd.%s" $argocdSecretDomain | quote }}
     application.resourceTrackingMethod: annotation+label
     kustomize.buildOptions: --enable-helm
+    oidc.config: |
+      name: Google
+      issuer: https://accounts.google.com
+      clientID: {{ $argocdOIDCClientID | quote }}
+      clientSecret: $oidc.google.clientSecret
+      requestedScopes:
+        - openid
+        - profile
+        - email
+      requestedIDTokenClaims:
+        email:
+          essential: true
   cmp:
     create: true
     plugins:
@@ -60,7 +73,21 @@ configs:
           args:
             - |
               set -eu
-              SOPS_BIN=/custom-tools/sops ../../../../../scripts/render-argocd-app.sh .
+              SEARCH_DIR="$(pwd)"
+              SCRIPT_PATH=""
+              while [ "${SEARCH_DIR}" != "/" ]; do
+                CANDIDATE="${SEARCH_DIR}/scripts/render-argocd-app.sh"
+                if [ -f "${CANDIDATE}" ]; then
+                  SCRIPT_PATH="${CANDIDATE}"
+                  break
+                fi
+                SEARCH_DIR="$(dirname "${SEARCH_DIR}")"
+              done
+              if [ -z "${SCRIPT_PATH}" ]; then
+                echo "render-argocd-app.sh not found from $(pwd)" >&2
+                exit 1
+              fi
+              SOPS_BIN=/custom-tools/sops /bin/sh "${SCRIPT_PATH}" .
   params:
     server.insecure: "true"
   rbac:
@@ -74,9 +101,9 @@ configs:
       p, role:readonly, applications, get, */*, allow
       p, role:readonly, projects, get, *, allow
       p, role:readonly, repositories, get, *, allow
-      p, role:readonly, applications, sync, */*, deny
-      p, role:readonly, applications, override, */*, deny
       g, argocd-admins, role:admin
+      g, admin, role:admin
+      g, juftin@gmail.com, role:admin
       g, argocd-maintainers, role:readonly
     scopes: '[groups, email]'
 repoServer:

--- a/bootstrap/helmfile.d/templates/values.yaml.gotmpl
+++ b/bootstrap/helmfile.d/templates/values.yaml.gotmpl
@@ -2,6 +2,7 @@
 {{- $argocdTargetRevision := env "ARGOCD_TARGET_REVISION" | default "refs/heads/main" }}
 {{- $argocdSecretDomain := env "ARGOCD_SECRET_DOMAIN" | default "example.com" }}
 {{- $argocdOIDCClientID := env "ARGOCD_OIDC_CLIENT_ID" | default "706743218818-jp4s5vunfp9ac1euuu4j0sh5t46palg6.apps.googleusercontent.com" }}
+{{- $argocdRBACAdmins := env "ARGOCD_RBAC_ADMINS" | default "" }}
 crds:
   install: true
 extraObjects:
@@ -102,8 +103,9 @@ configs:
       p, role:readonly, projects, get, *, allow
       p, role:readonly, repositories, get, *, allow
       g, argocd-admins, role:admin
-      g, admin, role:admin
-      g, juftin@gmail.com, role:admin
+{{- if $argocdRBACAdmins }}
+{{ $argocdRBACAdmins | nindent 6 }}
+{{- end }}
       g, argocd-maintainers, role:readonly
     scopes: '[groups, email]'
 repoServer:

--- a/bootstrap/helmfile.d/templates/values.yaml.gotmpl
+++ b/bootstrap/helmfile.d/templates/values.yaml.gotmpl
@@ -1,7 +1,7 @@
 {{- if and (eq .Release.Name "argocd") (eq .Release.Namespace "argocd") }}
 {{- $argocdTargetRevision := env "ARGOCD_TARGET_REVISION" | default "refs/heads/main" }}
 {{- $argocdSecretDomain := env "ARGOCD_SECRET_DOMAIN" | default "example.com" }}
-{{- $argocdOIDCClientID := env "ARGOCD_OIDC_CLIENT_ID" | default "706743218818-jp4s5vunfp9ac1euuu4j0sh5t46palg6.apps.googleusercontent.com" }}
+{{- $argocdOIDCClientID := env "ARGOCD_OIDC_CLIENT_ID" | default "" }}
 {{- $argocdRBACAdmins := env "ARGOCD_RBAC_ADMINS" | default "" }}
 crds:
   install: true

--- a/scripts/bootstrap-apps.sh
+++ b/scripts/bootstrap-apps.sh
@@ -59,6 +59,7 @@ function apply_sops_secrets() {
 
     local -r secrets=(
         "${ROOT_DIR}/bootstrap/github-deploy-key.sops.yaml"
+        "${ROOT_DIR}/bootstrap/argocd-oidc-secret.sops.yaml"
         "${ROOT_DIR}/bootstrap/sops-age.sops.yaml"
         "${ROOT_DIR}/kubernetes/components/sops/cluster-secrets.sops.yaml"
     )

--- a/templates/config/bootstrap/helmfile.d/templates/values.yaml.gotmpl.j2
+++ b/templates/config/bootstrap/helmfile.d/templates/values.yaml.gotmpl.j2
@@ -60,7 +60,21 @@ configs:
           args:
             - |
               set -eu
-              SOPS_BIN=/custom-tools/sops ../../../../../scripts/render-argocd-app.sh .
+              SEARCH_DIR="$(pwd)"
+              SCRIPT_PATH=""
+              while [ "${SEARCH_DIR}" != "/" ]; do
+                CANDIDATE="${SEARCH_DIR}/scripts/render-argocd-app.sh"
+                if [ -f "${CANDIDATE}" ]; then
+                  SCRIPT_PATH="${CANDIDATE}"
+                  break
+                fi
+                SEARCH_DIR="$(dirname "${SEARCH_DIR}")"
+              done
+              if [ -z "${SCRIPT_PATH}" ]; then
+                echo "render-argocd-app.sh not found from $(pwd)" >&2
+                exit 1
+              fi
+              SOPS_BIN=/custom-tools/sops /bin/sh "${SCRIPT_PATH}" .
   params:
     server.insecure: "true"
   rbac:

--- a/templates/config/bootstrap/helmfile.d/templates/values.yaml.gotmpl.j2
+++ b/templates/config/bootstrap/helmfile.d/templates/values.yaml.gotmpl.j2
@@ -1,6 +1,7 @@
 {{- if and (eq .Release.Name "argocd") (eq .Release.Namespace "argocd") }}
 {{- $argocdTargetRevision := env "ARGOCD_TARGET_REVISION" | default "refs/heads/main" }}
 {{- $argocdSecretDomain := env "ARGOCD_SECRET_DOMAIN" | default "example.com" }}
+{{- $argocdRBACAdmins := env "ARGOCD_RBAC_ADMINS" | default "" }}
 crds:
   install: true
 extraObjects:
@@ -91,6 +92,9 @@ configs:
       p, role:readonly, applications, sync, */*, deny
       p, role:readonly, applications, override, */*, deny
       g, argocd-admins, role:admin
+{{- if $argocdRBACAdmins }}
+{{ $argocdRBACAdmins | nindent 6 }}
+{{- end }}
       g, argocd-maintainers, role:readonly
     scopes: '[groups, email]'
 repoServer:

--- a/templates/config/bootstrap/helmfile.d/templates/values.yaml.gotmpl.j2
+++ b/templates/config/bootstrap/helmfile.d/templates/values.yaml.gotmpl.j2
@@ -1,6 +1,7 @@
 {{- if and (eq .Release.Name "argocd") (eq .Release.Namespace "argocd") }}
 {{- $argocdTargetRevision := env "ARGOCD_TARGET_REVISION" | default "refs/heads/main" }}
 {{- $argocdSecretDomain := env "ARGOCD_SECRET_DOMAIN" | default "example.com" }}
+{{- $argocdOIDCClientID := env "ARGOCD_OIDC_CLIENT_ID" | default "" }}
 {{- $argocdRBACAdmins := env "ARGOCD_RBAC_ADMINS" | default "" }}
 crds:
   install: true
@@ -50,6 +51,18 @@ configs:
     url: {{ printf "https://argocd.%s" $argocdSecretDomain | quote }}
     application.resourceTrackingMethod: annotation+label
     kustomize.buildOptions: --enable-helm
+    oidc.config: |
+      name: Google
+      issuer: https://accounts.google.com
+      clientID: {{ $argocdOIDCClientID | quote }}
+      clientSecret: $oidc.google.clientSecret
+      requestedScopes:
+        - openid
+        - profile
+        - email
+      requestedIDTokenClaims:
+        email:
+          essential: true
   cmp:
     create: true
     plugins:


### PR DESCRIPTION
## Summary
- fix ArgoCD CMP manifest generation to resolve and execute scripts/render-argocd-app.sh from any app source depth
- invoke the render script via /bin/sh to avoid executable-bit or mount execution issues in plugin sidecars
- add bootstrap secret wiring for ArgoCD Google OIDC client secret
- include ArgoCD OIDC config/client ID and admin RBAC mappings in bootstrap values

## Validation
- task dev:validate
- task argocd:bootstrap
- verified home-ops-root returns Synced and Healthy after hard refresh
