### PR TITLE
⬆️ migrate loki to community chart (grafana/helm-charts → grafana-community/helm-charts)

### DIFF
--- a/kubernetes/apps/observability/loki/app/kustomization.yaml
+++ b/kubernetes/apps/observability/loki/app/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 helmCharts:
   - name: loki
-    repo: oci://ghcr.io/grafana/helm-charts
-    version: 6.55.0
+    repo: oci://ghcr.io/grafana-community/helm-charts/loki
+    version: 17.1.1
     releaseName: loki
     namespace: observability
     includeCRDs: true


### PR DESCRIPTION
Migrate Loki from the official Grafana helm chart to the community-maintained chart.

**Background:** The `oci://ghcr.io/grafana/helm-charts` repo switched to **Grafana Enterprise Logs (GEL) only** as of v7.0.0. OSS Loki has moved to `grafana-community/helm-charts`, forked from chart version 6.55.0.

| | Before | After |
|---|---|---|
| Chart repo | `oci://ghcr.io/grafana/helm-charts` | `oci://ghcr.io/grafana-community/helm-charts/loki` |
| Chart version | `6.55.0` | `17.1.1` |
| Loki app version | `3.6.7` | `3.7.2` |

**Breaking changes checked:** ❌ None for this config
- `SingleBinary` mode with `filesystem` storage → fully compatible
- No MinIO dependency (community chart deprecated it in 17.0.0)
- All existing values (serviceMonitor, persistence, retention, etc.) map 1:1

**What changes in the rendered manifests:**
- New sidecar `loki-sc-rules` for auto-loading recording rules from ConfigMaps (idle unless used)
- Liveness probe added (`/loki/api/v1/status/buildinfo`)
- Security hardening: `seccompProfile: RuntimeDefault`
- Better defaults: WAL flush on shutdown, memberlist retry/backoff, GRPC tuning
- New `ServiceAccount/loki-memcached` (security isolation)

**ArgoCD:** The existing `ignore-extraneous-diffs.yaml` patch handles the new sidecar container cleanly.

Closes #102